### PR TITLE
Build static binaries for better portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION ?=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_SYMBOL := github.com/venslabs/vens/cmd/vens/version.Version
 
+export CGO_ENABLED ?= 0
+
 GO ?= go
 GO_LDFLAGS ?= -s -w -X $(VERSION_SYMBOL)=$(VERSION)
 GO_BUILD ?= $(GO) build -trimpath -ldflags="$(GO_LDFLAGS)"


### PR DESCRIPTION
Set `CGO_ENABLED=0` to produce statically linked binaries that don't require specific glibc versions. This fixes compatibility issues on older systems like RHEL/Alma 8.

Resolve part of #66