### PR TITLE
docs: simplify pitch across all entry points for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 [![GitHub Downloads][github-downloads-img]][release]
 [![Documentation][docs-img]][docs]
 
-# vens - Context-Aware Vulnerability Risk Scoring
+# vens — Prioritize vulnerabilities by real risk, not just CVSS
 
-**Stop treating all vulnerabilities equally.** Vens transforms generic CVSS scores into **contextual OWASP risk scores** tailored to YOUR system using LLM intelligence, and outputs standards-compliant **[CycloneDX VEX](https://www.ntia.gov/files/ntia/publications/vex_one-page_summary.pdf)**.
+**Your scanner found 300 CVEs. Which ones actually matter?** Vens takes a Trivy or Grype report, combines it with a description of _your_ system (exposure, data sensitivity, compliance, security controls), and scores every CVE based on its real risk to you — not just its generic severity.
+
+The output is a [CycloneDX VEX](https://www.ntia.gov/files/ntia/publications/vex_one-page_summary.pdf) file with [OWASP Risk Rating](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) scores.
 
 > 📖 **[Read the full documentation →](https://venslabs.github.io/vens/)**
 >

--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -37,7 +37,7 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate INPUT OUTPUT",
-		Short: "Generate CycloneDx VEX with OWASP risk scores using LLM",
+		Short: "Score CVEs by real risk, output CycloneDX VEX",
 		Long: `Generate Vulnerability-Exploitability eXchange (VEX) information using an LLM to prioritize CVEs based on risk.
 
 The LLM analyzes each vulnerability using the project context hints you provide:

--- a/docs/TRIVY_PLUGIN.md
+++ b/docs/TRIVY_PLUGIN.md
@@ -1,6 +1,6 @@
 # Vens as a Trivy Plugin
 
-Use vens as a [Trivy plugin](https://trivy.dev/docs/latest/plugin/) to transform generic CVSS scores into contextual OWASP risk scores.
+Use vens as a [Trivy plugin](https://trivy.dev/docs/latest/plugin/) to prioritize vulnerabilities by real risk, not just CVSS.
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,10 @@
 # Vens
 
-**Stop treating all vulnerabilities equally.** Vens turns generic CVSS scores into **contextual OWASP risk scores** tailored to _your_ system, and outputs a standards-compliant **CycloneDX VEX** file.
+**Your scanner found 300 CVEs. Which ones actually matter?**
 
-Give Vens a Trivy or Grype report plus a short description of your system, and it tells you which CVEs actually matter.
+Give Vens a Trivy or Grype report plus a short description of your system — exposure, data sensitivity, compliance, security controls — and it scores every CVE based on its real risk to _you_, not just its generic CVSS severity.
+
+The output is a [CycloneDX VEX](https://cyclonedx.org/capabilities/vex/) file with [OWASP Risk Rating](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) scores.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Vens
-site_description: Context-aware vulnerability risk scoring with LLM-powered CycloneDX VEX
+site_description: Prioritize vulnerabilities by real risk, not just CVSS. Scores each CVE based on your system's actual context.
 site_url: https://venslabs.github.io/vens/
 repo_url: https://github.com/venslabs/vens
 repo_name: venslabs/vens


### PR DESCRIPTION
Replaces jargon-heavy taglines with plain-English descriptions across every entry point a new visitor hits first.

The old pitch ("transforms generic CVSS scores into contextual OWASP risk scores tailored to YOUR system using LLM intelligence, and outputs standards-compliant CycloneDX VEX") requires knowing 5 acronyms to parse. The new pitch starts with the problem ("Your scanner found 300 CVEs. Which ones actually matter?") and explains the how in plain words.

Changed files: README.md title + intro, docs/index.md intro, mkdocs.yml site_description, docs/TRIVY_PLUGIN.md opening line, generate.go cobra Short field. Technical detail (CycloneDX VEX, OWASP Risk Rating) stays in second-line references with hyperlinks, not removed.

Deep pages (reference, concepts, guides) are unchanged — jargon is appropriate there because the reader has already been introduced to the concepts.