### PR TITLE
docs: add GitHub Actions integration guide

### DIFF
--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -32,6 +32,8 @@ Add this to your workflow after a container or dependency scan:
       ${{ steps.vens.outputs.enriched-report }}
 ```
 
+For tighter supply-chain control, pin by commit SHA instead of the mutable tag: `uses: venslabs/vens-action@5e8b440b...  # v0.1.0`. Dependabot and Renovate both track SHA-pinned actions.
+
 ## About vens-action
 
 The action wraps the [vens CLI](../reference/generate.md). It expects a Trivy or Grype JSON report, your `config.yaml`, and an LLM provider API key. It outputs a VEX file and severity counts you can use to fail the build.

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -71,6 +71,7 @@ Pre-install the vens binary and pass `bin-path`:
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: ollama
     llm-base-url: http://ollama.corp.example:11434
+    llm-model: llama3.1
 ```
 
 ## For details

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -1,0 +1,74 @@
+# GitHub Actions Integration
+
+Drop [vens-action](https://github.com/marketplace/actions/vens-action) into your pipeline after a Trivy or Grype scan to re-score every CVE in your project's context and produce a CycloneDX VEX file.
+
+## Quickstart
+
+Add this to your workflow after a container or dependency scan:
+
+```yaml
+- name: Scan image with Trivy
+  run: trivy image python:3.11-slim --format json --output report.json
+
+- name: Prioritize with vens
+  id: vens
+  uses: venslabs/vens-action@v0.1.0
+  with:
+    version: v0.3.2
+    config-file: .vens/config.yaml
+    input-report: report.json
+    sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+    llm-provider: openai
+    llm-model: gpt-4o
+    llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+    fail-on-severity: critical
+    enrich: "true"
+
+- uses: actions/upload-artifact@v4
+  with:
+    name: vens-output
+    path: |
+      ${{ steps.vens.outputs.vex-file }}
+      ${{ steps.vens.outputs.enriched-report }}
+```
+
+## About vens-action
+
+The action wraps the [vens CLI](../reference/generate.md). It expects a Trivy or Grype JSON report, your `config.yaml`, and an LLM provider API key. It outputs a VEX file and severity counts you can use to fail the build.
+
+Key difference from running `vens generate` directly: the action handles binary installation (from a release tag or pre-installed path), extracts `sbom-serial-number` for BOM-Link anchoring, and exposes counts as workflow outputs for downstream steps.
+
+## Using the mock provider in CI
+
+For testing or cost savings, use the `mock` LLM provider — it returns fixed scores and costs nothing:
+
+```yaml
+- uses: venslabs/vens-action@v0.1.0
+  with:
+    version: v0.3.2
+    config-file: .vens/config.yaml
+    input-report: report.json
+    sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+    llm-provider: mock
+```
+
+Good for gating builds on presence of a VEX file without calling external LLM services.
+
+## Air-gapped runners
+
+Pre-install the vens binary and pass `bin-path`:
+
+```yaml
+- uses: venslabs/vens-action@v0.1.0
+  with:
+    bin-path: /opt/bin/vens
+    config-file: .vens/config.yaml
+    input-report: report.json
+    sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+    llm-provider: ollama
+    llm-base-url: http://ollama.corp.example:11434
+```
+
+## For details
+
+See the [vens-action README](https://github.com/venslabs/vens-action#readme) for the full input/output reference and platform support notes.

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -40,6 +40,8 @@ The action wraps the [vens CLI](../reference/generate.md). It expects a Trivy or
 
 Key difference from running `vens generate` directly: the action handles binary installation (from a release tag or pre-installed path), extracts `sbom-serial-number` for BOM-Link anchoring, and exposes counts as workflow outputs for downstream steps.
 
+The `llm-api-key` is passed as an environment variable (never a CLI argument) and masked in workflow logs via `::add-mask::` before any step runs.
+
 ## Using the mock provider in CI
 
 For testing or cost savings, use the `mock` LLM provider — it returns fixed scores and costs nothing:

--- a/docs/guides/prioritize-cves.md
+++ b/docs/guides/prioritize-cves.md
@@ -150,11 +150,11 @@ Grype supports `--vex` as well. Dependency-Track can ingest the VEX file directl
 
 ## Put it in CI
 
-A typical GitHub Actions step:
+For a turnkey Action, see [GitHub Actions integration](github-actions.md). The manual approach below works too:
 
 ```yaml
 - name: Install Vens
-  run: go install github.com/venslabs/vens/cmd/vens@v0.3.0
+  run: go install github.com/venslabs/vens/cmd/vens@v0.3.2
 
 - name: Scan image
   run: trivy image $IMAGE --format json --output report.json

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,9 @@ Vens reads your scanner report, combines it with _your_ system context (exposure
 - :material-arrow-collapse-right: **[Enrich your report](reference/enrich.md)**
   Fold OWASP scores back into your Trivy report.
 
+- :material-github: **[GitHub Actions](guides/github-actions.md)**
+  Drop vens into your CI pipeline.
+
 </div>
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Guides:
       - Prioritize a CVE backlog: guides/prioritize-cves.md
       - Describe your context: guides/configuration.md
+      - GitHub Actions integration: guides/github-actions.md
   - Concepts:
       - What is a VEX file?: concepts/what-is-vex.md
       - CVSS vs OWASP contextual: concepts/cvss-vs-owasp.md


### PR DESCRIPTION
Add vens-action quickstart and integration details to Guides section.

- New page: `docs/guides/github-actions.md` with YAML examples for standard, mock, and air-gapped setups
- Updated nav in `mkdocs.yml` to link the new guide
- Links to upstream vens-action repo and Marketplace for full reference

No changes to home page — integration guide is naturally discoverable via Guides nav.