### PR TITLE
docs: lead install paths with GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ Risk = Likelihood × Impact (0-81 scale)
 
 **[GitHub Action](https://github.com/marketplace/actions/vens-action):**
 ```yaml
-- uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag
+- uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
-    config-file: .vens/config.yaml
+    version: v0.3.2                   # vens binary version
+    config-file: .vens/config.yaml    # see docs/guides/configuration.md to author this file
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: openai
     llm-model: gpt-4o
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+    fail-on-severity: critical        # break the build on critical OWASP risk
 ```
 
 See the [GitHub Actions guide](https://venslabs.github.io/vens/guides/github-actions/) for the full input/output reference.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,27 @@ Risk = Likelihood × Impact (0-81 scale)
 
 ## Installation
 
-**Standalone:**
-```bash
-go install github.com/venslabs/vens/cmd/vens@latest
+**[GitHub Action](https://github.com/marketplace/actions/vens-action):**
+```yaml
+- uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag
+  with:
+    config-file: .vens/config.yaml
+    input-report: report.json
+    sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+    llm-provider: openai
+    llm-model: gpt-4o
+    llm-api-key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-**[Trivy Plugin](https://trivy.dev/docs/latest/plugin/):**
+See the [GitHub Actions guide](https://venslabs.github.io/vens/guides/github-actions/) for the full input/output reference.
+
+**Run Vens locally:**
+
 ```bash
+# Go install
+go install github.com/venslabs/vens/cmd/vens@latest
+
+# Or as a Trivy plugin (https://trivy.dev/docs/latest/plugin/)
 trivy plugin install github.com/venslabs/vens
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,13 +1,38 @@
 # Installation
 
 **Who this is for:** anyone getting started with Vens.
-**By the end of this page:** you have `vens` (or `trivy vens`) running on your machine, with an LLM provider configured and a scanner available.
-
-Vens ships as a single static binary. Pick the method that fits your workflow.
+**By the end of this page:** you have Vens running — either as a CI step or as a local CLI binary.
 
 ---
 
-## Prerequisites
+## GitHub Action
+
+If you scan with Trivy or Grype in GitHub Actions, drop [`venslabs/vens-action`](https://github.com/marketplace/actions/vens-action) into the workflow after the scan step:
+
+```yaml
+- name: Scan image with Trivy
+  run: trivy image python:3.11-slim --format json --output report.json
+
+- name: Prioritize with vens
+  uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag
+  with:
+    config-file: .vens/config.yaml
+    input-report: report.json
+    sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+    llm-provider: openai
+    llm-model: gpt-4o
+    llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The action installs the binary, runs `vens generate`, and exposes severity counts as workflow outputs you can fail the build on. Full input/output reference, air-gapped runners, and the mock provider: see the **[GitHub Actions integration guide](../guides/github-actions.md)**.
+
+---
+
+## Run Vens locally
+
+Vens ships as a single static binary. Pick the method that fits your workflow.
+
+### Prerequisites
 
 Vens is not a scanner — it consumes reports produced by one. Before you start, make sure you have **one** of the following installed:
 
@@ -18,7 +43,7 @@ You will also need credentials for an LLM provider (OpenAI, Anthropic, Google AI
 
 ---
 
-## Option 1 — Go install (recommended for developers)
+### Option 1 — Go install (recommended for developers)
 
 ```bash
 go install github.com/venslabs/vens/cmd/vens@latest
@@ -38,7 +63,7 @@ vens --version
 
 ---
 
-## Option 2 — Trivy plugin (recommended for Trivy users)
+### Option 2 — Trivy plugin (recommended for Trivy users)
 
 If you already use Trivy, install Vens as a native plugin — no separate binary to manage.
 
@@ -56,7 +81,7 @@ From now on, anywhere in this documentation where you see `vens <command>`, you 
 
 ---
 
-## Option 3 — Prebuilt binary
+### Option 3 — Prebuilt binary
 
 Download the latest release for your OS/architecture from the [releases page](https://github.com/venslabs/vens/releases), extract it, and put it in your `$PATH`.
 
@@ -101,17 +126,19 @@ Download the latest release for your OS/architecture from the [releases page](ht
 
 ---
 
-## Configure an LLM provider
+### Configure an LLM provider
 
 Vens calls an LLM to score each CVE. All four providers below are first-class — pick whichever matches your constraints. Export credentials for **one**:
+
+Vens asks the LLM to return structured JSON with four 0–9 component scores per CVE. If a model emits malformed JSON, you'll see `unable to parse LLM output` — see [troubleshooting](../troubleshooting.md).
 
 === "Ollama (local, no cloud, zero cost)"
 
     Run Ollama on the host where Vens runs (or another host on the same network), then pull a model:
 
     ```bash
-    ollama pull llama3.1:70b    # recommended for OWASP scoring quality
-    # Lighter options if you are hardware-constrained:
+    ollama pull llama3.1:70b
+    # Lighter alternatives:
     # ollama pull llama3.1:8b
     # ollama pull mistral:7b
 
@@ -120,11 +147,7 @@ Vens calls an LLM to score each CVE. All four providers below are first-class �
     export OLLAMA_HOST="http://ollama.internal:11434"
     ```
 
-    **Model size matters.** Vens asks the LLM to return structured JSON with four 0–9 component scores per CVE. Models under 7B parameters routinely emit malformed JSON on batches of 10 CVEs. If you see `unable to parse LLM output` errors in [troubleshooting](../troubleshooting.md), move up one model tier or lower `--llm-batch-size` to 3–5.
-
-    **Hardware rule of thumb:** `llama3.1:70b` needs a GPU with ≥48 GB VRAM (or an Apple Silicon box with ≥64 GB unified memory); `llama3.1:8b` runs on a modern laptop with ≥16 GB RAM.
-
-    Nothing leaves the machine(s) running Ollama and Vens — see [Privacy and data flow](../concepts/privacy-and-data-flow.md).
+    Nothing leaves the machine running Ollama — see [Privacy and data flow](../concepts/privacy-and-data-flow.md).
 
 === "OpenAI"
 
@@ -133,7 +156,7 @@ Vens calls an LLM to score each CVE. All four providers below are first-class �
     export OPENAI_MODEL="gpt-4o"
     ```
 
-    OpenAI currently honours the `seed` parameter Vens forwards, giving the lowest cross-run score drift among cloud providers.
+    Among the cloud providers, only OpenAI currently accepts the `seed` parameter Vens forwards (`--llm-seed`); Anthropic and Google AI silently ignore it. This does not guarantee byte-identical scores across runs — see [Reference: `--llm-seed`](../reference/generate.md#--llm-seed-int) and [Limitations](../concepts/limitations.md).
 
 === "Anthropic"
 
@@ -159,13 +182,7 @@ Auto-detection currently defaults to **OpenAI**. If you use a different provider
 ```
 
 !!! warning "LLM cost"
-    Cloud LLM pricing changes frequently and depends on model tier, prompt size, and the number of CVEs in your report. Vens does **not** estimate cost for you. To get a real number for your own environment:
-
-    - Run Vens once on a representative report with `--debug-dir ./debug`.
-    - Count the tokens in `debug/system.prompt` and `debug/human.prompt` (multiply by the batch count).
-    - Plug those numbers into your provider's pricing page.
-
-    As a rough order of magnitude at the time of writing, a single-scan run of ~200 CVEs with `gpt-4o` falls in the "cents to low dollars" range. **Treat this as back-of-envelope only** and always validate against your actual provider invoice before scaling to production CI. For zero-cost or air-gapped deployments, use the Ollama tab above.
+    Cloud LLM pricing depends on model, prompt size, and CVE count. Vens does not estimate cost — run once against your provider and read the billing dashboard. For zero-cost or air-gapped runs, use Ollama.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,14 +14,16 @@ If you scan with Trivy or Grype in GitHub Actions, drop [`venslabs/vens-action`]
   run: trivy image python:3.11-slim --format json --output report.json
 
 - name: Prioritize with vens
-  uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag
+  uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
-    config-file: .vens/config.yaml
+    version: v0.3.2                   # vens binary version
+    config-file: .vens/config.yaml    # see ../guides/configuration.md to author this file
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: openai
     llm-model: gpt-4o
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+    fail-on-severity: critical        # break the build on critical OWASP risk
 ```
 
 The action installs the binary, runs `vens generate`, and exposes severity counts as workflow outputs you can fail the build on. Full input/output reference, air-gapped runners, and the mock provider: see the **[GitHub Actions integration guide](../guides/github-actions.md)**.
@@ -182,7 +184,11 @@ Auto-detection currently defaults to **OpenAI**. If you use a different provider
 ```
 
 !!! warning "LLM cost"
-    Cloud LLM pricing depends on model, prompt size, and CVE count. Vens does not estimate cost — run once against your provider and read the billing dashboard. For zero-cost or air-gapped runs, use Ollama.
+    Cloud LLM pricing depends on model, prompt size, and CVE count. Vens does not estimate cost.
+
+    For an exact number, run once against your provider and read the billing dashboard. For a pre-run estimate, run with `--debug-dir ./debug`, count the tokens in `debug/system.prompt`, and plug into your provider's pricing page (the `human.prompt` file is overwritten on every batch and output tokens are not captured, so this is approximate).
+
+    For zero-cost or air-gapped runs, use Ollama.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,11 @@ Vens reads your scanner report, combines it with _your_ system context (exposure
 
 <div class="grid cards" markdown>
 
-- :material-download: **[Install Vens](getting-started/installation.md)**
-  Three commands, three options.
+- :material-github: **[GitHub Actions](guides/github-actions.md)**
+  Drop Vens into your Trivy/Grype pipeline.
+
+- :material-download: **[Install the CLI](getting-started/installation.md)**
+  Run Vens locally.
 
 - :material-rocket-launch: **[Quickstart (5 minutes)](getting-started/quickstart.md)**
   Your first VEX file from a real image.
@@ -63,9 +66,6 @@ Vens reads your scanner report, combines it with _your_ system context (exposure
 
 - :material-arrow-collapse-right: **[Enrich your report](reference/enrich.md)**
   Fold OWASP scores back into your Trivy report.
-
-- :material-github: **[GitHub Actions](guides/github-actions.md)**
-  Drop vens into your CI pipeline.
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,12 +63,12 @@ exclude_docs: |
 nav:
   - Home: index.md
   - Getting Started:
+      - GitHub Actions: guides/github-actions.md
       - Installation: getting-started/installation.md
       - Quickstart (5 min): getting-started/quickstart.md
   - Guides:
       - Prioritize a CVE backlog: guides/prioritize-cves.md
       - Describe your context: guides/configuration.md
-      - GitHub Actions integration: guides/github-actions.md
   - Concepts:
       - What is a VEX file?: concepts/what-is-vex.md
       - CVSS vs OWASP contextual: concepts/cvss-vs-owasp.md


### PR DESCRIPTION
Action-first across README, docs index, install page and mkdocs nav. Snippets carry version pinning, fail-on-severity, a SHA-pin hint and a cross-link to the config guide.

Closes #126