### PR TITLE
docs: pass the SBOM serialNumber to --sbom-serial-number, not a random UUID

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -64,7 +64,7 @@ This is the step that makes scores meaningful. A dev/test environment would use 
 
 ## Step 3 — Generate the VEX
 
-`vens generate` needs a `--sbom-serial-number` in `urn:uuid:<uuid>` form (it is used to build BOM-Link references in the VEX). Generate one once:
+`--sbom-serial-number` is the `serialNumber` of the CycloneDX SBOM paired with this scan — Vens uses it to build BOM-Link references back to that SBOM. Extract it from the SBOM (`jq -r .serialNumber sbom.cdx.json`), or for this quickstart generate an ad-hoc one:
 
 ```bash
 # Linux / macOS

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -213,7 +213,7 @@ Once you have more than one service scanned by Vens, copy-pasting the same `conf
 The pattern that works:
 
 - **One `config.yaml` per service, lives in the service's own repository**, typically under `.vens/config.yaml`. It ships and versions with the code it describes.
-- **One stable BOM-Link UUID per service**, stored as a repository/environment variable next to the config file. Reuse it forever on every CI run — see [`--sbom-serial-number`](../reference/generate.md#--sbom-serial-number-urnuuid).
+- **A canonical CycloneDX SBOM per service**: pass its `serialNumber` to [`--sbom-serial-number`](../reference/generate.md#--sbom-serial-number-urnuuid) so each `affects` entry in the VEX resolves back to that SBOM via BOM-Link. Reuse the same SBOM across rescans of the same artefact for stable references.
 - If you have genuinely shared defaults across many services (e.g. every fintech service under the same compliance perimeter), maintain a **template** in a central repo and have services vendor it with a short delta file on top. Avoid inheritance engines — YAML merging is a maintenance trap.
 - If you maintain an internal platform, publish a **tiered catalogue** (`dev-sandbox.yaml`, `internal-tool.yaml`, `customer-facing.yaml`, `pci-scope.yaml`) and let service owners pick the closest one as their starting point.
 

--- a/docs/guides/prioritize-cves.md
+++ b/docs/guides/prioritize-cves.md
@@ -86,7 +86,7 @@ vens generate \
   output.vex.json
 ```
 
-`--sbom-serial-number` is required — it feeds the BOM-Link references in the VEX. Store the UUID alongside the service if you want stable BOM-Links across runs.
+`--sbom-serial-number` is required — pass the `serialNumber` of the CycloneDX SBOM paired with this scan so each `affects` in the VEX resolves back to that SBOM via BOM-Link.
 
 Runtime: ~1 minute for 300 CVEs with `gpt-4o`.
 

--- a/docs/reference/generate.md
+++ b/docs/reference/generate.md
@@ -34,7 +34,7 @@ Path to your [`config.yaml`](config-schema.md) file.
 
 ### `--sbom-serial-number <urn:uuid:...>`
 
-UUID used to build the BOM-Link `urn:cdx:<uuid>/<version>#<bom-ref>` references in the generated VEX. **Must** be provided and **must** start with `urn:uuid:`. Reuse the same UUID across runs when you want stable BOM-Links (for example when linking the VEX back to a specific SBOM in CI).
+The `serialNumber` of the CycloneDX SBOM paired with this scan. Vens uses it to build the BOM-Link `urn:cdx:<uuid>/<version>#<bom-ref>` references in the generated VEX so each `affects` entry resolves back to that SBOM. **Required** and **must** start with `urn:uuid:`.
 
 ```bash
 vens generate \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ vens generate --config-file config.yaml --sbom-serial-number "$SBOM_UUID" report
 
 ## `sbom-serial-number is required`
 
-`vens generate` needs `--sbom-serial-number` in `urn:uuid:<uuid>` form — it feeds the BOM-Link references in the VEX. Generate one once:
+`vens generate` needs `--sbom-serial-number` — it must be the `serialNumber` of the CycloneDX SBOM paired with this scan, in `urn:uuid:<uuid>` form. Extract it from the SBOM (`jq -r .serialNumber sbom.cdx.json`), or for ad-hoc runs generate one:
 
 ```bash
 SBOM_UUID="urn:uuid:$(uuidgen | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
The flag value must be the \`serialNumber\` of the CycloneDX SBOM paired with the scan so each \`affects\` in the VEX resolves back to that SBOM via BOM-Link. Replaces \`uuidgen\` recipes with a \`trivy --format cyclonedx\` step + \`jq -r .serialNumber\` extraction; Action snippets feed it via a runtime extract step.