### PR TITLE
ci: sign release checksums with cosign (keyless OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,13 @@ jobs:
 
     - name: "Install cosign"
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        cosign-release: 'v3.0.6'
 
     - name: "Sign SHA256SUMS with cosign (keyless)"
       run: |
         cosign sign-blob --yes \
-          --output-signature _output/SHA256SUMS.sig \
-          --output-certificate _output/SHA256SUMS.pem \
+          --bundle _output/SHA256SUMS.sigstore.json \
           _output/SHA256SUMS
 
     - name: "Create release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
       with:
         subject-path: _output/*
 
+    - name: "Install cosign"
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+    - name: "Sign SHA256SUMS with cosign (keyless)"
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        cosign sign-blob --yes \
+          --output-signature _output/SHA256SUMS.sig \
+          --output-certificate _output/SHA256SUMS.pem \
+          _output/SHA256SUMS
+
     - name: "Create release"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: "Sign SHA256SUMS with cosign (keyless)"
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
         cosign sign-blob --yes \
           --output-signature _output/SHA256SUMS.sig \

--- a/README.md
+++ b/README.md
@@ -54,29 +54,6 @@ go install github.com/venslabs/vens/cmd/vens@latest
 trivy plugin install github.com/venslabs/vens
 ```
 
-## Verifying releases
-
-Release artifacts are signed with [cosign](https://github.com/sigstore/cosign)
-keyless signing (Sigstore, GitHub Actions OIDC — no long-lived keys). Each
-release ships `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the
-signing certificate `SHA256SUMS.pem`.
-
-```bash
-# Verify the signature over SHA256SUMS
-cosign verify-blob \
-  --certificate SHA256SUMS.pem \
-  --signature SHA256SUMS.sig \
-  --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  SHA256SUMS
-
-# Then verify the downloaded artifacts against the trusted checksums
-sha256sum --check --ignore-missing SHA256SUMS
-```
-
-Releases also carry a GitHub build-provenance attestation, verifiable with
-`gh attestation verify <artifact> --repo venslabs/vens`.
-
 ## Quick Example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ go install github.com/venslabs/vens/cmd/vens@latest
 trivy plugin install github.com/venslabs/vens
 ```
 
+## Verifying releases
+
+Release artifacts are signed with [cosign](https://github.com/sigstore/cosign)
+keyless signing (Sigstore, GitHub Actions OIDC — no long-lived keys). Each
+release ships `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the
+signing certificate `SHA256SUMS.pem`.
+
+```bash
+# Verify the signature over SHA256SUMS
+cosign verify-blob \
+  --certificate SHA256SUMS.pem \
+  --signature SHA256SUMS.sig \
+  --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  SHA256SUMS
+
+# Then verify the downloaded artifacts against the trusted checksums
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+Releases also carry a GitHub build-provenance attestation, verifiable with
+`gh attestation verify <artifact> --repo venslabs/vens`.
+
 ## Quick Example
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -128,6 +128,26 @@ Download the latest release for your OS/architecture from the [releases page](ht
 
 ---
 
+### Verify the download
+
+Release artifacts are signed with [cosign](https://github.com/sigstore/cosign) keyless signing (Sigstore, GitHub Actions OIDC — no long-lived keys). Each release publishes `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the signing certificate `SHA256SUMS.pem`. Download all three alongside your archive from the [releases page](https://github.com/venslabs/vens/releases), then:
+
+```bash
+cosign verify-blob \
+  --certificate SHA256SUMS.pem \
+  --signature SHA256SUMS.sig \
+  --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  SHA256SUMS
+
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+!!! note
+    Releases also carry a GitHub build-provenance attestation. Verify it with `gh attestation verify <archive> --repo venslabs/vens`.
+
+---
+
 ### Configure an LLM provider
 
 Vens calls an LLM to score each CVE. All four providers below are first-class — pick whichever matches your constraints. Export credentials for **one**:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -130,7 +130,7 @@ Download the latest release for your OS/architecture from the [releases page](ht
 
 ### Verify the download
 
-Release artifacts are signed with [cosign](https://github.com/sigstore/cosign) keyless signing (Sigstore, GitHub Actions OIDC — no long-lived keys). Each release publishes `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the signing certificate `SHA256SUMS.pem`. Download all three alongside your archive from the [releases page](https://github.com/venslabs/vens/releases), then:
+Release artifacts are signed with [cosign](https://github.com/sigstore/cosign) in keyless mode: the signing identity is the GitHub Actions release workflow itself, certified by Sigstore — no long-lived key. Each release publishes `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the signing certificate `SHA256SUMS.pem`. Download all three alongside your archive from the [releases page](https://github.com/venslabs/vens/releases), then:
 
 ```bash
 cosign verify-blob \

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -130,12 +130,11 @@ Download the latest release for your OS/architecture from the [releases page](ht
 
 ### Verify the download
 
-Release artifacts are signed with [cosign](https://github.com/sigstore/cosign) in keyless mode: the signing identity is the GitHub Actions release workflow itself, certified by Sigstore — no long-lived key. Each release publishes `SHA256SUMS`, its detached signature `SHA256SUMS.sig`, and the signing certificate `SHA256SUMS.pem`. Download all three alongside your archive from the [releases page](https://github.com/venslabs/vens/releases), then:
+Release artifacts are signed with [cosign](https://github.com/sigstore/cosign) in keyless mode: the signing identity is the GitHub Actions release workflow itself, certified by Sigstore — no long-lived key. Each release publishes `SHA256SUMS` and its Sigstore bundle `SHA256SUMS.sigstore.json` (signature, certificate, and transparency-log proof in one file). Download both alongside your archive from the [releases page](https://github.com/venslabs/vens/releases), then:
 
 ```bash
 cosign verify-blob \
-  --certificate SHA256SUMS.pem \
-  --signature SHA256SUMS.sig \
+  --bundle SHA256SUMS.sigstore.json \
   --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   SHA256SUMS

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -16,6 +16,22 @@ tar -xzf vens-<VERSION>-<OS>-<ARCH>.tar.gz
 sudo mv vens /usr/local/bin/
 \`\`\`
 
+### Verifying this release
+Release artifacts are signed with cosign keyless (Sigstore, GitHub Actions OIDC).
+\`\`\`bash
+# Verify the signature over the checksums file
+cosign verify-blob \\
+  --certificate SHA256SUMS.pem \\
+  --signature SHA256SUMS.sig \\
+  --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \\
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
+  SHA256SUMS
+
+# Then check your downloaded archive against the trusted checksums
+sha256sum --check --ignore-missing SHA256SUMS
+\`\`\`
+A GitHub build-provenance attestation is also published; see the docs for verification.
+
 ## Quick start
 \`\`\`bash
 export OPENAI_API_KEY="your-key"

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -17,7 +17,7 @@ sudo mv vens /usr/local/bin/
 \`\`\`
 
 ### Verifying this release
-Release artifacts are signed with cosign keyless (Sigstore, GitHub Actions OIDC).
+Release artifacts are signed with cosign keyless — Sigstore cert bound to the GitHub Actions release workflow identity.
 \`\`\`bash
 # Verify the signature over the checksums file
 cosign verify-blob \\

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -21,8 +21,7 @@ Release artifacts are signed with cosign keyless — Sigstore cert bound to the 
 \`\`\`bash
 # Verify the signature over the checksums file
 cosign verify-blob \\
-  --certificate SHA256SUMS.pem \\
-  --signature SHA256SUMS.sig \\
+  --bundle SHA256SUMS.sigstore.json \\
   --certificate-identity-regexp '^https://github.com/venslabs/vens/\.github/workflows/release\.yml@refs/tags/v' \\
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
   SHA256SUMS


### PR DESCRIPTION
cosign keyless signing of the release SHA256SUMS (GitHub Actions OIDC), next to the existing build-provenance attestation. `cosign verify-blob` is the path consumers and Scorecard's Signed-Releases check expect. Verify steps live in the install docs + the generated release note.

#123 step 4 only.
