### PR TITLE
feat: opt-in CDXA attestation sibling file (--attest)

### DIFF
--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -25,6 +25,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/venslabs/vens/cmd/vens/version"
+	"github.com/venslabs/vens/pkg/attestation"
 	"github.com/venslabs/vens/pkg/generator"
 	"github.com/venslabs/vens/pkg/llm"
 	"github.com/venslabs/vens/pkg/llm/llmfactory"
@@ -66,6 +68,7 @@ The LLM calculates the OWASP risk score (0-81) for each vulnerability using:
 	flags.String("debug-dir", "", "Directory to save debug files (prompts, responses)")
 	flags.String("sbom-serial-number", "", "SBOM serial number for BOM-Link (format: urn:uuid:...)")
 	flags.Int("sbom-version", 1, "SBOM version for BOM-Link (default: 1)")
+	flags.Bool("attest", false, "Emit a CycloneDX Attestations (CDXA) sibling file with prompt hash, input hash, model, seed, raw LLM response")
 
 	return cmd
 }
@@ -129,7 +132,8 @@ func action(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	o.LLM, err = llmfactory.New(ctx, llmName)
+	var provider, model string
+	o.LLM, provider, model, err = llmfactory.New(ctx, llmName)
 	if err != nil {
 		return err
 	}
@@ -146,6 +150,11 @@ func action(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	o.DebugDir, err = flags.GetString("debug-dir")
+	if err != nil {
+		return err
+	}
+
+	attestEnabled, err := flags.GetBool("attest")
 	if err != nil {
 		return err
 	}
@@ -209,9 +218,12 @@ func action(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to extract SBOM metadata: %w", err)
 	}
 
+	// The VEX gets its own serialNumber; the attestation links back to it.
+	vexUUID := uuid.NewString()
+
 	switch outputFormat {
 	case "cyclonedxvex":
-		h = outputhandler.NewCycloneDxVexOutputHandler(outputW, sbomUUID, sbomVersion)
+		h = outputhandler.NewCycloneDxVexOutputHandler(outputW, sbomUUID, sbomVersion, vexUUID)
 	default:
 		return fmt.Errorf("unknown output format %q", outputFormat)
 	}
@@ -232,12 +244,46 @@ func action(cmd *cobra.Command, args []string) error {
 
 	slog.InfoContext(ctx, "Processing vulnerabilities", "count", len(vulns))
 
+	var attestor *attestation.Builder
+	if attestEnabled {
+		attestor = attestation.NewBuilder(attestation.Opts{
+			VensVersion: version.GetVersion(),
+			Provider:    provider,
+			Model:       model,
+			Seed:        o.Seed,
+			InputHash:   attestation.HashInput(inputB),
+			VEXUUID:     vexUUID,
+			VEXVersion:  sbomVersion,
+		})
+		g.SetAttestor(attestor)
+	}
+
 	// Generate risk scores using LLM
 	if err = g.GenerateRiskScore(ctx, vulns, h.HandleVulnRatings); err != nil {
 		return fmt.Errorf("failed to generate risk scores: %w", err)
 	}
 
-	return h.Close()
+	if err := h.Close(); err != nil {
+		return err
+	}
+
+	if attestor != nil && attestor.BatchCount() > 0 {
+		atPath := attestation.SiblingPath(outputPath)
+		atW, err := os.Create(atPath)
+		if err != nil {
+			return fmt.Errorf("failed to create attestation file %q: %w", atPath, err)
+		}
+		if err := attestor.Write(atW); err != nil {
+			atW.Close() //nolint:errcheck
+			return fmt.Errorf("failed to write attestation: %w", err)
+		}
+		if err := atW.Close(); err != nil {
+			return fmt.Errorf("failed to close attestation file %q: %w", atPath, err)
+		}
+		slog.InfoContext(ctx, "Attestation written", "path", atPath, "batches", attestor.BatchCount())
+	}
+
+	return nil
 }
 
 // extractSBOMMetadata extracts UUID and version from flags.

--- a/cmd/vens/testdata/script/generate_attest.txt
+++ b/cmd/vens/testdata/script/generate_attest.txt
@@ -1,0 +1,78 @@
+# --attest emits a CDXA sibling file with per-batch LLM evidence
+
+exec vens generate --llm=mock --attest --llm-seed=7 --config-file=config.yaml --sbom-serial-number=urn:uuid:11111111-2222-3333-4444-555555555555 report.json output.cdx.json
+stderr 'Processing vulnerabilities'
+stderr 'Attestation written'
+
+exists output.cdx.json
+exists output.attestation.cdx.json
+
+# CDX 1.7 BOM with declarations.evidence
+json-contains output.attestation.cdx.json '"bomFormat": "CycloneDX"'
+json-contains output.attestation.cdx.json '"specVersion": "1.7"'
+json-contains output.attestation.cdx.json '"declarations"'
+json-contains output.attestation.cdx.json '"evidence"'
+
+# Links back to the VEX via a BOM-Link external reference (not the SBOM serial)
+json-contains output.attestation.cdx.json '"bom-ref": "vens-vex"'
+json-contains output.attestation.cdx.json '"type": "bom"'
+
+# Producing tool version is recorded
+json-contains output.attestation.cdx.json '"name": "vens"'
+
+# Per-batch evidence carries the minimum reproducibility field set
+json-contains output.attestation.cdx.json '"bom-ref": "evidence-batch-1"'
+json-contains output.attestation.cdx.json '"name": "prompt_hash"'
+json-contains output.attestation.cdx.json '"name": "input_hash"'
+json-contains output.attestation.cdx.json '"name": "model"'
+json-contains output.attestation.cdx.json '"name": "seed"'
+json-contains output.attestation.cdx.json '"name": "raw_response"'
+json-contains output.attestation.cdx.json '"encoding": "base64"'
+
+# Evidence values, not just field names
+json-contains output.attestation.cdx.json '"content": "mock/mock"'
+json-contains output.attestation.cdx.json '"content": "7"'
+
+-- config.yaml --
+project:
+  name: "attest-test"
+  description: "Test project for attestation integration"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+-- report.json --
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2024-01-15T10:00:00Z",
+  "ArtifactName": "nginx:1.25",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "nginx:1.25 (debian 12.4)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-1234",
+          "PkgID": "openssl@3.0.11-1~deb12u2",
+          "PkgName": "openssl",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/openssl@3.0.11-1~deb12u2?arch=amd64&distro=debian-12.4"
+          },
+          "InstalledVersion": "3.0.11-1~deb12u2",
+          "FixedVersion": "3.0.13-1~deb12u1",
+          "Status": "fixed",
+          "Title": "OpenSSL: Buffer overflow in SSL_select_next_proto",
+          "Description": "A buffer overflow vulnerability in OpenSSL.",
+          "Severity": "HIGH",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://security-tracker.debian.org/tracker/CVE-2024-1234"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/vens/testdata/script/generate_attest_empty.txt
+++ b/cmd/vens/testdata/script/generate_attest_empty.txt
@@ -1,0 +1,31 @@
+# --attest with a vulnerability-free report writes the VEX but no attestation sibling
+
+exec vens generate --llm=mock --attest --config-file=config.yaml --sbom-serial-number=urn:uuid:88888888-8888-8888-8888-888888888888 report.json output.cdx.json
+stderr 'No vulnerabilities found'
+
+exists output.cdx.json
+! exists output.attestation.cdx.json
+
+-- config.yaml --
+project:
+  name: "attest-empty-test"
+  description: "Test project for attestation with no vulnerabilities"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+-- report.json --
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2024-01-15T10:00:00Z",
+  "ArtifactName": "nginx:1.25",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "nginx:1.25 (debian 12.4)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": []
+    }
+  ]
+}

--- a/cmd/vens/testdata/script/generate_attest_optin.txt
+++ b/cmd/vens/testdata/script/generate_attest_optin.txt
@@ -1,0 +1,49 @@
+# Without --attest, the CDXA sibling file must NOT be created (opt-in default-off)
+
+exec vens generate --llm=mock --config-file=config.yaml --sbom-serial-number=urn:uuid:99999999-9999-9999-9999-999999999999 report.json output.cdx.json
+exists output.cdx.json
+! exists output.attestation.cdx.json
+
+-- config.yaml --
+project:
+  name: "attest-optin-test"
+  description: "Test project for attestation opt-in default"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+-- report.json --
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2024-01-15T10:00:00Z",
+  "ArtifactName": "nginx:1.25",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "nginx:1.25 (debian 12.4)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-1234",
+          "PkgID": "openssl@3.0.11-1~deb12u2",
+          "PkgName": "openssl",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/openssl@3.0.11-1~deb12u2?arch=amd64&distro=debian-12.4"
+          },
+          "InstalledVersion": "3.0.11-1~deb12u2",
+          "FixedVersion": "3.0.13-1~deb12u1",
+          "Status": "fixed",
+          "Title": "OpenSSL: Buffer overflow",
+          "Description": "A buffer overflow vulnerability in OpenSSL.",
+          "Severity": "HIGH",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://security-tracker.debian.org/tracker/CVE-2024-1234"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/reference/generate.md
+++ b/docs/reference/generate.md
@@ -164,6 +164,34 @@ Per-CVE component scores and the LLM's reasoning are logged to stderr at `INFO`/
 !!! note "Retention for compliance workloads"
     If you need the debug output as audit evidence (HIPAA-style 6-year retention, SOC 2 change log, PCI-DSS risk decisions), store it in the same encrypted, access-controlled system you use for other security audit logs. Treat each `--debug-dir` directory as one entry in your vulnerability-triage evidence chain, indexed by scan date and by the Git SHA of the `config.yaml` that produced it. Reasoning can only be reconstructed later if **both** the `config.yaml` version and the debug files are preserved — a copy of the VEX alone is not enough.
 
+### `--attest`
+
+Opt-in. Emits a [CycloneDX Attestations (CDXA)](https://cyclonedx.org/specification/overview/) sibling file next to the VEX, capturing what the LLM saw and produced so the run can be audited and reproduced later. Off by default.
+
+```bash
+vens generate --attest \
+  --config-file c.yaml \
+  --sbom-serial-number "$SBOM_UUID" \
+  report.json out.cdx.json
+# writes out.cdx.json AND out.attestation.cdx.json
+```
+
+**Schema** (CDX 1.7 BOM, one `declarations.evidence[]` entry per LLM batch):
+
+- `prompt_hash` — SHA-256 of `system_prompt + "\n\n" + human_prompt`
+- `input_hash` — SHA-256 of the scanner input report bytes
+- `model` — the `<provider>/<model>` used for the run (e.g. `openai/gpt-4o`). When the provider's `*_MODEL` env var is unset, vens falls back to that provider's default model and logs it.
+- `seed` — the LLM seed (`0` if unset)
+- `raw_response` — base64-encoded raw LLM JSON response
+
+The producing `vens` version is recorded in `metadata.tools`. The attestation is a `file` component that links to the VEX it describes through a `bom` external reference (`urn:cdx:<vex-serial>/<version>`).
+
+!!! note "Reproducibility scope"
+    The attestation records the inputs and outputs of each LLM call. Recreating a score also requires the `config.yaml` used at the time — keep it under version control alongside the attestation.
+
+!!! warning "The attestation is sensitive — store it like audit evidence"
+    `raw_response` is **base64-encoded, not encrypted** — anyone with the file can decode it back to the model's reply: the CVE IDs you scored, their scores, and the free-text reasoning (which reflects your `config.yaml` context). The prompt and scanner report are stored only as SHA-256 hashes, so the raw vulnerability list and package versions are not embedded. In CI, write the attestation to the same access-controlled store as your other security evidence — not to a public build artifact.
+
 ### `--sbom-version <int>`
 
 BOM-Link `version` number used alongside `--sbom-serial-number`. Default: `1`.

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -1,0 +1,195 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package attestation builds the CycloneDX Attestations (CDXA) sibling file for
+// a vens VEX: prompt hash, input hash, model, seed, raw LLM response.
+package attestation
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	cyclonedx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/google/uuid"
+)
+
+// Opts configures a Builder. Set once per run.
+type Opts struct {
+	VensVersion string
+	Provider    string
+	Model       string
+	Seed        int
+	InputHash   string
+	VEXUUID     string
+	VEXVersion  int
+	Now         func() time.Time
+}
+
+// Builder collects per-batch evidence and emits a CDX 1.7 BOM with
+// declarations.evidence[].
+type Builder struct {
+	opts    Opts
+	batches []batchEvidence
+}
+
+type batchEvidence struct {
+	promptHash  string
+	rawResponse []byte
+	at          time.Time
+}
+
+// HashInput returns the hex-encoded SHA-256 of b.
+func HashInput(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// SiblingPath returns the attestation path next to a VEX output path:
+// foo.cdx.json, foo.json and foo all yield foo.attestation.cdx.json.
+func SiblingPath(vexPath string) string {
+	base := strings.TrimSuffix(vexPath, ".json")
+	base = strings.TrimSuffix(base, ".cdx")
+	return base + ".attestation.cdx.json"
+}
+
+// NewBuilder returns a Builder.
+func NewBuilder(opts Opts) *Builder {
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Builder{opts: opts}
+}
+
+// AddBatch records evidence for a single LLM batch. systemPrompt and humanPrompt
+// are hashed together (SHA-256 of system + "\n\n" + human); rawResponse is the
+// raw bytes returned by the LLM.
+func (b *Builder) AddBatch(systemPrompt, humanPrompt string, rawResponse []byte) {
+	sum := sha256.Sum256([]byte(systemPrompt + "\n\n" + humanPrompt))
+	b.batches = append(b.batches, batchEvidence{
+		promptHash:  hex.EncodeToString(sum[:]),
+		rawResponse: append([]byte(nil), rawResponse...),
+		at:          b.opts.Now().UTC(),
+	})
+}
+
+// BatchCount returns the number of batches recorded.
+func (b *Builder) BatchCount() int { return len(b.batches) }
+
+// Write serializes the attestation as a CycloneDX 1.7 JSON BOM.
+// Returns an error if no batches were recorded.
+func (b *Builder) Write(w io.Writer) error {
+	if len(b.batches) == 0 {
+		return fmt.Errorf("attestation: no batches recorded")
+	}
+
+	bom := cyclonedx.NewBOM()
+	bom.SerialNumber = "urn:uuid:" + uuid.NewString()
+	bom.Version = 1
+	bom.Metadata = &cyclonedx.Metadata{
+		Timestamp: b.opts.Now().UTC().Format(time.RFC3339),
+	}
+	if b.opts.VensVersion != "" {
+		bom.Metadata.Tools = &cyclonedx.ToolsChoice{
+			Components: &[]cyclonedx.Component{
+				{
+					Type:    cyclonedx.ComponentTypeApplication,
+					Name:    "vens",
+					Version: b.opts.VensVersion,
+				},
+			},
+		}
+	}
+	if b.opts.VEXUUID != "" {
+		v := b.opts.VEXVersion
+		if v == 0 {
+			v = 1
+		}
+		// The attestation is a file; it points at the VEX BOM it describes via a
+		// BOM-Link external reference (not via bom-ref, which is a local id).
+		bom.Metadata.Component = &cyclonedx.Component{
+			Type:   cyclonedx.ComponentTypeFile,
+			BOMRef: "vens-vex",
+			Name:   "vens-vex",
+			ExternalReferences: &[]cyclonedx.ExternalReference{
+				{
+					Type: cyclonedx.ERTypeBOM,
+					URL:  fmt.Sprintf("urn:cdx:%s/%d", b.opts.VEXUUID, v),
+				},
+			},
+		}
+	}
+
+	// "provider/model", or just whichever part is set (no dangling slash).
+	model := b.opts.Model
+	switch {
+	case b.opts.Provider != "" && model != "":
+		model = b.opts.Provider + "/" + model
+	case model == "":
+		model = b.opts.Provider
+	}
+	evidence := make([]cyclonedx.DeclarationEvidence, 0, len(b.batches))
+	for i, e := range b.batches {
+		data := []cyclonedx.EvidenceData{
+			textData("prompt_hash", e.promptHash),
+			textData("input_hash", b.opts.InputHash),
+			textData("model", model),
+			textData("seed", fmt.Sprintf("%d", b.opts.Seed)),
+			base64Data("raw_response", e.rawResponse, "application/json"),
+		}
+		evidence = append(evidence, cyclonedx.DeclarationEvidence{
+			BOMRef:      fmt.Sprintf("evidence-batch-%d", i+1),
+			Description: fmt.Sprintf("LLM scoring batch %d", i+1),
+			Created:     e.at.Format(time.RFC3339),
+			Data:        &data,
+		})
+	}
+	bom.Declarations = &cyclonedx.Declarations{Evidence: &evidence}
+
+	enc := cyclonedx.NewBOMEncoder(w, cyclonedx.BOMFileFormatJSON)
+	enc.SetPretty(true)
+	if err := enc.EncodeVersion(bom, cyclonedx.SpecVersion1_7); err != nil {
+		return fmt.Errorf("attestation: encode: %w", err)
+	}
+	return nil
+}
+
+func textData(name, value string) cyclonedx.EvidenceData {
+	return cyclonedx.EvidenceData{
+		Name: name,
+		Contents: &cyclonedx.EvidenceDataContents{
+			Attachment: &cyclonedx.AttachedText{
+				Content:     value,
+				ContentType: "text/plain",
+			},
+		},
+	}
+}
+
+func base64Data(name string, value []byte, contentType string) cyclonedx.EvidenceData {
+	return cyclonedx.EvidenceData{
+		Name: name,
+		Contents: &cyclonedx.EvidenceDataContents{
+			Attachment: &cyclonedx.AttachedText{
+				Content:     base64.StdEncoding.EncodeToString(value),
+				ContentType: contentType,
+				Encoding:    "base64",
+			},
+		},
+	}
+}

--- a/pkg/attestation/attestation_test.go
+++ b/pkg/attestation/attestation_test.go
@@ -1,0 +1,240 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fixedNow(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func newTestBuilder(t *testing.T, mod func(*Opts)) *Builder {
+	t.Helper()
+	o := Opts{
+		VensVersion: "v0.0.0-test",
+		Provider:    "openai",
+		Model:       "gpt-4o",
+		Seed:        42,
+		InputHash:   HashInput([]byte(`{"hello":"world"}`)),
+		VEXUUID:     "11111111-2222-3333-4444-555555555555",
+		VEXVersion:  1,
+		Now:         fixedNow(time.Date(2026, 5, 25, 10, 0, 0, 0, time.UTC)),
+	}
+	if mod != nil {
+		mod(&o)
+	}
+	return NewBuilder(o)
+}
+
+// evidenceFields decodes an attestation BOM and returns the first batch's
+// evidence as a name->content map.
+func evidenceFields(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	var got struct {
+		Declarations struct {
+			Evidence []struct {
+				Data []struct {
+					Name     string `json:"name"`
+					Contents struct {
+						Attachment struct {
+							Content string `json:"content"`
+						} `json:"attachment"`
+					} `json:"contents"`
+				} `json:"data"`
+			} `json:"evidence"`
+		} `json:"declarations"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.NotEmpty(t, got.Declarations.Evidence)
+	fields := map[string]string{}
+	for _, d := range got.Declarations.Evidence[0].Data {
+		fields[d.Name] = d.Contents.Attachment.Content
+	}
+	return fields
+}
+
+func TestHashInput_Deterministic(t *testing.T) {
+	want := sha256.Sum256([]byte("payload"))
+	assert.Equal(t, hex.EncodeToString(want[:]), HashInput([]byte("payload")))
+}
+
+func TestBuilder_AddBatch_HashesSystemPlusHuman(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	b.AddBatch("sys", "hum", []byte(`{"ok":true}`))
+	require.Equal(t, 1, b.BatchCount())
+	want := sha256.Sum256([]byte("sys\n\nhum"))
+	assert.Equal(t, hex.EncodeToString(want[:]), b.batches[0].promptHash)
+}
+
+func TestBuilder_Write_NoBatches_Errors(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	require.Error(t, b.Write(&bytes.Buffer{}))
+}
+
+func TestBuilder_Write_StructureAndFields(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	raw := []byte(`{"results":[{"vulnId":"CVE-X"}]}`)
+	b.AddBatch("sys", "hum", raw)
+
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+
+	var got struct {
+		BomFormat    string `json:"bomFormat"`
+		SpecVersion  string `json:"specVersion"`
+		SerialNumber string `json:"serialNumber"`
+		Version      int    `json:"version"`
+		Metadata     struct {
+			Timestamp string `json:"timestamp"`
+			Tools     struct {
+				Components []struct {
+					Type    string `json:"type"`
+					Name    string `json:"name"`
+					Version string `json:"version"`
+				} `json:"components"`
+			} `json:"tools"`
+			Component struct {
+				Type               string `json:"type"`
+				BomRef             string `json:"bom-ref"`
+				Name               string `json:"name"`
+				ExternalReferences []struct {
+					Type string `json:"type"`
+					URL  string `json:"url"`
+				} `json:"externalReferences"`
+			} `json:"component"`
+		} `json:"metadata"`
+		Declarations struct {
+			Evidence []struct {
+				BomRef      string `json:"bom-ref"`
+				Description string `json:"description"`
+				Created     string `json:"created"`
+				Data        []struct {
+					Name     string `json:"name"`
+					Contents struct {
+						Attachment struct {
+							Content     string `json:"content"`
+							ContentType string `json:"contentType"`
+							Encoding    string `json:"encoding"`
+						} `json:"attachment"`
+					} `json:"contents"`
+				} `json:"data"`
+			} `json:"evidence"`
+		} `json:"declarations"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output:\n%s", buf.String())
+
+	assert.Equal(t, "CycloneDX", got.BomFormat)
+	assert.Equal(t, "1.7", got.SpecVersion)
+	assert.True(t, strings.HasPrefix(got.SerialNumber, "urn:uuid:"), "serialNumber=%q", got.SerialNumber)
+	assert.Equal(t, 1, got.Version)
+	assert.Equal(t, "2026-05-25T10:00:00Z", got.Metadata.Timestamp)
+	assert.Equal(t, "file", got.Metadata.Component.Type)
+	assert.Equal(t, "vens-vex", got.Metadata.Component.BomRef)
+	require.Len(t, got.Metadata.Component.ExternalReferences, 1)
+	assert.Equal(t, "bom", got.Metadata.Component.ExternalReferences[0].Type)
+	assert.Equal(t, "urn:cdx:11111111-2222-3333-4444-555555555555/1", got.Metadata.Component.ExternalReferences[0].URL)
+	require.Len(t, got.Metadata.Tools.Components, 1)
+	assert.Equal(t, "vens", got.Metadata.Tools.Components[0].Name)
+	assert.Equal(t, "v0.0.0-test", got.Metadata.Tools.Components[0].Version)
+
+	require.Len(t, got.Declarations.Evidence, 1)
+	ev := got.Declarations.Evidence[0]
+	assert.Equal(t, "evidence-batch-1", ev.BomRef)
+	assert.Equal(t, "2026-05-25T10:00:00Z", ev.Created)
+
+	fields := map[string]string{}
+	encodings := map[string]string{}
+	for _, d := range ev.Data {
+		fields[d.Name] = d.Contents.Attachment.Content
+		encodings[d.Name] = d.Contents.Attachment.Encoding
+	}
+
+	wantPrompt := sha256.Sum256([]byte("sys\n\nhum"))
+	assert.Equal(t, hex.EncodeToString(wantPrompt[:]), fields["prompt_hash"])
+	assert.Equal(t, HashInput([]byte(`{"hello":"world"}`)), fields["input_hash"])
+	assert.Equal(t, "openai/gpt-4o", fields["model"])
+	assert.Equal(t, "42", fields["seed"])
+
+	gotResp, err := base64.StdEncoding.DecodeString(fields["raw_response"])
+	require.NoError(t, err, "raw_response not base64")
+	assert.Equal(t, raw, gotResp)
+	assert.Equal(t, "base64", encodings["raw_response"])
+}
+
+func TestBuilder_Write_NoVEXUUID_NoComponent(t *testing.T) {
+	b := newTestBuilder(t, func(o *Opts) { o.VEXUUID = "" })
+	b.AddBatch("s", "h", []byte("{}"))
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+	var got struct {
+		Metadata struct {
+			Component *struct{} `json:"component,omitempty"`
+		} `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Nil(t, got.Metadata.Component, "metadata.component should be omitted when VEXUUID empty")
+}
+
+func TestBuilder_Write_ProviderEmpty_ModelStandsAlone(t *testing.T) {
+	b := newTestBuilder(t, func(o *Opts) { o.Provider = "" })
+	b.AddBatch("s", "h", []byte("{}"))
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+	assert.Equal(t, "gpt-4o", evidenceFields(t, buf.Bytes())["model"])
+}
+
+func TestBuilder_Write_ModelEmpty_ProviderStandsAlone(t *testing.T) {
+	b := newTestBuilder(t, func(o *Opts) { o.Model = "" })
+	b.AddBatch("s", "h", []byte("{}"))
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+	// An unset model must not produce a dangling "provider/".
+	assert.Equal(t, "openai", evidenceFields(t, buf.Bytes())["model"])
+}
+
+func TestBuilder_Write_MultipleBatches(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	b.AddBatch("s1", "h1", []byte("{}"))
+	b.AddBatch("s2", "h2", []byte("{}"))
+	b.AddBatch("s3", "h3", []byte("{}"))
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+	s := buf.String()
+	for _, want := range []string{"evidence-batch-1", "evidence-batch-2", "evidence-batch-3"} {
+		assert.Contains(t, s, want)
+	}
+}
+
+func TestSiblingPath(t *testing.T) {
+	tests := map[string]string{
+		"out.cdx.json":      "out.attestation.cdx.json",
+		"out.json":          "out.attestation.cdx.json",
+		"out":               "out.attestation.cdx.json",
+		"dir/scan.cdx.json": "dir/scan.attestation.cdx.json",
+	}
+	for in, want := range tests {
+		assert.Equal(t, want, SiblingPath(in))
+	}
+}

--- a/pkg/generator/attestor_test.go
+++ b/pkg/generator/attestor_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/venslabs/vens/internal/testutil"
+	"github.com/venslabs/vens/pkg/attestation"
+	"github.com/venslabs/vens/pkg/riskconfig"
+)
+
+func testVulns(n int) []Vulnerability {
+	v := make([]Vulnerability, n)
+	for i := range v {
+		v[i] = Vulnerability{VulnID: fmt.Sprintf("CVE-2024-%04d", i), PkgName: "pkg", Title: "t"}
+	}
+	return v
+}
+
+// One evidence batch is recorded per LLM call, so BatchCount tracks the batching.
+func TestGenerator_Attestor_OneBatchPerLLMCall(t *testing.T) {
+	at := attestation.NewBuilder(attestation.Opts{Provider: "mock", Model: "mock"})
+	g, err := New(Opts{LLM: testutil.NewMockLLM(), Config: &riskconfig.Config{}, BatchSize: 10})
+	require.NoError(t, err)
+	g.SetAttestor(at)
+
+	require.NoError(t, g.GenerateRiskScore(context.Background(), testVulns(15), nil))
+	require.Equal(t, 2, at.BatchCount()) // 15 vulns / batch size 10 -> 2 batches
+}
+
+type failingLLM struct{}
+
+func (failingLLM) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	return nil, errors.New("llm down")
+}
+
+func (failingLLM) Call(context.Context, string, ...llms.CallOption) (string, error) {
+	return "", errors.New("llm down")
+}
+
+// A failed LLM call must not record evidence, or the attestation would carry
+// empty/garbage batches.
+func TestGenerator_Attestor_NoBatchOnLLMError(t *testing.T) {
+	at := attestation.NewBuilder(attestation.Opts{Provider: "mock", Model: "mock"})
+	g, err := New(Opts{LLM: failingLLM{}, Config: &riskconfig.Config{}})
+	require.NoError(t, err)
+	g.SetAttestor(at)
+
+	require.Error(t, g.GenerateRiskScore(context.Background(), testVulns(3), nil))
+	require.Equal(t, 0, at.BatchCount())
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/tmc/langchaingo/jsonschema"
 	"github.com/tmc/langchaingo/llms"
+	"github.com/venslabs/vens/pkg/attestation"
 	"github.com/venslabs/vens/pkg/llm"
 	"github.com/venslabs/vens/pkg/outputhandler"
 	"github.com/venslabs/vens/pkg/owasp"
@@ -106,7 +107,8 @@ type Opts struct {
 
 // Generator produces OWASP risk scores using LLM analysis.
 type Generator struct {
-	o Opts
+	o        Opts
+	attestor *attestation.Builder
 }
 
 // New creates a new Generator with the given options.
@@ -135,6 +137,9 @@ func New(o Opts) (*Generator, error) {
 	}
 	return g, nil
 }
+
+// SetAttestor attaches an attestation Builder after construction. Pass nil to disable.
+func (g *Generator) SetAttestor(b *attestation.Builder) { g.attestor = b }
 
 // GenerateRiskScore generates contextual OWASP risk scores for the given vulnerabilities.
 // It uses the LLM to calculate the OWASP risk score for each vulnerability based on
@@ -320,6 +325,10 @@ func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerab
 		return err
 	}); err != nil {
 		return nil, err
+	}
+
+	if g.attestor != nil {
+		g.attestor.AddBatch(systemPrompt, humanPrompt, buf.Bytes())
 	}
 
 	// Parse LLM response

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 )
@@ -70,4 +71,39 @@ func isRateLimit(err error) bool {
 	}
 
 	return false
+}
+
+// defaultModels mirror each provider's own default, used when *_MODEL is unset.
+// vens sets the model explicitly so it can record and log which one ran.
+// Ollama has no default.
+var defaultModels = map[string]string{
+	OpenAI:    "gpt-3.5-turbo",
+	Anthropic: "claude-3-5-sonnet-20240620",
+	GoogleAI:  "gemini-pro",
+	Mock:      "mock",
+}
+
+// ResolveModel returns the provider and model for a backend name. Provider
+// defaults to openai; model comes from the provider's *_MODEL env var, falling
+// back to defaultModels. defaulted reports that fallback.
+func ResolveModel(name string) (provider, model string, defaulted bool) {
+	provider = name
+	if provider == "" || provider == Auto {
+		provider = OpenAI
+	}
+	switch provider {
+	case OpenAI:
+		model = os.Getenv("OPENAI_MODEL")
+	case Ollama:
+		model = os.Getenv("OLLAMA_MODEL")
+	case Anthropic:
+		model = os.Getenv("ANTHROPIC_MODEL")
+	case GoogleAI:
+		model = os.Getenv("GOOGLE_MODEL")
+	}
+	if model == "" {
+		model = defaultModels[provider]
+		defaulted = true
+	}
+	return
 }

--- a/pkg/llm/llm_test.go
+++ b/pkg/llm/llm_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		env           map[string]string
+		wantProvider  string
+		wantModel     string
+		wantDefaulted bool
+	}{
+		{name: "openai from env", input: OpenAI, env: map[string]string{"OPENAI_MODEL": "gpt-4o"}, wantProvider: OpenAI, wantModel: "gpt-4o"},
+		{name: "auto resolves to openai from env", input: Auto, env: map[string]string{"OPENAI_MODEL": "gpt-4o"}, wantProvider: OpenAI, wantModel: "gpt-4o"},
+		{name: "empty resolves to openai from env", input: "", env: map[string]string{"OPENAI_MODEL": "gpt-4o"}, wantProvider: OpenAI, wantModel: "gpt-4o"},
+		{name: "openai unset falls back to default", input: OpenAI, wantProvider: OpenAI, wantModel: "gpt-3.5-turbo", wantDefaulted: true},
+		{name: "anthropic unset falls back to default", input: Anthropic, wantProvider: Anthropic, wantModel: "claude-3-5-sonnet-20240620", wantDefaulted: true},
+		{name: "googleai unset falls back to default", input: GoogleAI, wantProvider: GoogleAI, wantModel: "gemini-pro", wantDefaulted: true},
+		{name: "ollama from env", input: Ollama, env: map[string]string{"OLLAMA_MODEL": "llama3.1"}, wantProvider: Ollama, wantModel: "llama3.1"},
+		{name: "ollama unset has no default", input: Ollama, wantProvider: Ollama, wantModel: "", wantDefaulted: true},
+		{name: "mock", input: Mock, wantProvider: Mock, wantModel: "mock", wantDefaulted: true},
+		{name: "unknown passes through with empty model", input: "bogus", wantProvider: "bogus", wantModel: "", wantDefaulted: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Isolate env: clear all model vars, then apply the case's.
+			for _, k := range []string{"OPENAI_MODEL", "OLLAMA_MODEL", "ANTHROPIC_MODEL", "GOOGLE_MODEL"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			provider, model, defaulted := ResolveModel(tt.input)
+			assert.Equal(t, tt.wantProvider, provider)
+			assert.Equal(t, tt.wantModel, model)
+			assert.Equal(t, tt.wantDefaulted, defaulted)
+		})
+	}
+}

--- a/pkg/llm/llmfactory/llmfactory.go
+++ b/pkg/llm/llmfactory/llmfactory.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
@@ -31,36 +30,38 @@ import (
 	"github.com/venslabs/vens/pkg/llm"
 )
 
-// New instantiates an LLM.
-func New(ctx context.Context, name string) (llms.Model, error) {
-	switch name {
-	case "", llm.Auto:
+// New instantiates an LLM client and returns the resolved provider and model,
+// so callers can record what ran without resolving twice.
+func New(ctx context.Context, name string) (client llms.Model, provider, model string, err error) {
+	if name == "" || name == llm.Auto {
 		// TODO: add more sophisticated logic
 		slog.DebugContext(ctx, "Automatically choosing model", "name", llm.OpenAI)
-		name = llm.OpenAI
 	}
-	switch name {
-	case llm.OpenAI:
-		return openai.New()
-	case llm.Ollama:
-		var ollamaModel string
-		ollamaModel = os.Getenv("OLLAMA_MODEL")
-		return ollama.New(ollama.WithModel(ollamaModel))
-	case llm.Anthropic:
-		var anthropicModel string
-		anthropicModel = os.Getenv("ANTHROPIC_MODEL")
-		if anthropicModel != "" {
-			return anthropic.New(anthropic.WithModel(anthropicModel))
-		}
-		return anthropic.New()
-	case llm.GoogleAI:
-		var defaultModel string
-		defaultModel = os.Getenv("GOOGLE_MODEL")
-		return googleai.New(ctx, googleai.WithDefaultModel(defaultModel))
-	case llm.Mock:
+	var defaulted bool
+	provider, model, defaulted = llm.ResolveModel(name)
+	if provider == llm.Mock {
 		slog.DebugContext(ctx, "Using mock LLM for testing")
-		return testutil.NewMockLLM(), nil
-	default:
-		return nil, fmt.Errorf("unknown LLM %q, make sure to use one of %v", name, llm.Names)
+		client = testutil.NewMockLLM()
+		return
 	}
+	if defaulted && model != "" {
+		slog.WarnContext(ctx, "no model env var set; using the provider default", "provider", provider, "model", model)
+	}
+	switch provider {
+	case llm.OpenAI:
+		client, err = openai.New(openai.WithModel(model))
+	case llm.Ollama:
+		if model == "" {
+			err = fmt.Errorf("ollama: set the OLLAMA_MODEL environment variable")
+			return
+		}
+		client, err = ollama.New(ollama.WithModel(model))
+	case llm.Anthropic:
+		client, err = anthropic.New(anthropic.WithModel(model))
+	case llm.GoogleAI:
+		client, err = googleai.New(ctx, googleai.WithDefaultModel(model))
+	default:
+		err = fmt.Errorf("unknown LLM %q, make sure to use one of %v", name, llm.Names)
+	}
+	return
 }

--- a/pkg/outputhandler/cyclonedxvex.go
+++ b/pkg/outputhandler/cyclonedxvex.go
@@ -27,11 +27,13 @@ import (
 
 // NewCycloneDxVexOutputHandler returns an OutputHandler that accumulates
 // vulnerability ratings and emits a proper CycloneDX VEX BOM on Close.
-func NewCycloneDxVexOutputHandler(w io.Writer, sbomUUID string, sbomVersion int) OutputHandler {
+// vexUUID is the VEX document's serialNumber UUID; pass "" to generate one.
+func NewCycloneDxVexOutputHandler(w io.Writer, sbomUUID string, sbomVersion int, vexUUID string) OutputHandler {
 	return &cycloneDxVexWriter{
 		w:           w,
 		sbomUUID:    sbomUUID,
 		sbomVersion: sbomVersion,
+		vexUUID:     vexUUID,
 	}
 }
 
@@ -40,6 +42,7 @@ type cycloneDxVexWriter struct {
 	r           []VulnRating
 	sbomUUID    string
 	sbomVersion int
+	vexUUID     string
 	closed      bool
 }
 
@@ -56,7 +59,11 @@ func (c *cycloneDxVexWriter) Close() error {
 		return nil
 	}
 	bom := cyclonedx.NewBOM()
-	bom.SerialNumber = "urn:uuid:" + uuid.New().String()
+	serial := c.vexUUID
+	if serial == "" {
+		serial = uuid.New().String()
+	}
+	bom.SerialNumber = "urn:uuid:" + serial
 	bom.Version = c.sbomVersion
 	bom.Metadata = &cyclonedx.Metadata{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),

--- a/pkg/outputhandler/cyclonedxvex_test.go
+++ b/pkg/outputhandler/cyclonedxvex_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCycloneDxVexWriter_Close_SerialNumber(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	score := 42.0
 	err := h.HandleVulnRatings([]VulnRating{
@@ -69,7 +69,7 @@ func TestCycloneDxVexWriter_Close_SerialNumber(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_VersionFromSBOM(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 3)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 3, "")
 
 	if err := h.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -87,7 +87,7 @@ func TestCycloneDxVexWriter_Close_VersionFromSBOM(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_Metadata(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	if err := h.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -129,7 +129,7 @@ func TestCycloneDxVexWriter_Close_Metadata(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_VulnerabilitySource(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	score := 42.0
 	err := h.HandleVulnRatings([]VulnRating{
@@ -215,7 +215,7 @@ func TestCycloneDxVexWriter_Close_VulnerabilitySource(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_MergesDuplicateVulnIDs(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	score := 42.0
 	err := h.HandleVulnRatings([]VulnRating{
@@ -291,7 +291,7 @@ func TestCycloneDxVexWriter_Close_MergesDuplicateVulnIDs(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_DeduplicatesAffectsRefs(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	score := 42.0
 	err := h.HandleVulnRatings([]VulnRating{
@@ -341,7 +341,7 @@ func TestCycloneDxVexWriter_Close_DeduplicatesAffectsRefs(t *testing.T) {
 
 func TestCycloneDxVexWriter_Close_Idempotent(t *testing.T) {
 	var buf bytes.Buffer
-	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1)
+	h := NewCycloneDxVexOutputHandler(&buf, "test-uuid", 1, "")
 
 	if err := h.Close(); err != nil {
 		t.Fatalf("first Close: %v", err)


### PR DESCRIPTION
Step 1 of #138. Opt-in CDXA sibling file at `<vex>.attestation.cdx.json` capturing per-batch LLM evidence (`prompt_hash`, `input_hash`, `model`, `seed`, `raw_response`) for audit and reproduction. Off by default, enable with `--attest`.

Scope is step 1 only: per-batch evidence, no per-CVE claims, no signing. Coverage: unit 91.4% on `pkg/attestation` + 2 testscripts (`generate_attest`, `generate_attest_optin`).

Draft while I iterate.

Refs #138
