### PR TITLE
feat: attest per-CVE CDXA claims (--attest)

### DIFF
--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -110,7 +110,7 @@ func action(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load config.yaml with context hints
-	cfg, err := riskconfig.Load(configPath)
+	cfg, cfgBytes, err := riskconfig.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file %q: %w", configPath, err)
 	}
@@ -246,10 +246,6 @@ func action(cmd *cobra.Command, args []string) error {
 
 	var attestor *attestation.Builder
 	if attestEnabled {
-		var configHash string
-		if cfgB, rerr := os.ReadFile(configPath); rerr == nil {
-			configHash = attestation.HashInput(cfgB)
-		}
 		attestor = attestation.NewBuilder(attestation.Opts{
 			VensVersion:         version.GetVersion(),
 			Provider:            provider,
@@ -257,7 +253,7 @@ func action(cmd *cobra.Command, args []string) error {
 			Seed:                o.Seed,
 			Temperature:         o.Temperature,
 			InputHash:           attestation.HashInput(inputB),
-			ConfigHash:          configHash,
+			ConfigHash:          attestation.HashInput(cfgBytes),
 			PromptSchemaVersion: generator.PromptSchemaVersion,
 			VEXUUID:             vexUUID,
 			VEXVersion:          sbomVersion,

--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -246,14 +246,21 @@ func action(cmd *cobra.Command, args []string) error {
 
 	var attestor *attestation.Builder
 	if attestEnabled {
+		var configHash string
+		if cfgB, rerr := os.ReadFile(configPath); rerr == nil {
+			configHash = attestation.HashInput(cfgB)
+		}
 		attestor = attestation.NewBuilder(attestation.Opts{
-			VensVersion: version.GetVersion(),
-			Provider:    provider,
-			Model:       model,
-			Seed:        o.Seed,
-			InputHash:   attestation.HashInput(inputB),
-			VEXUUID:     vexUUID,
-			VEXVersion:  sbomVersion,
+			VensVersion:         version.GetVersion(),
+			Provider:            provider,
+			Model:               model,
+			Seed:                o.Seed,
+			Temperature:         o.Temperature,
+			InputHash:           attestation.HashInput(inputB),
+			ConfigHash:          configHash,
+			PromptSchemaVersion: generator.PromptSchemaVersion,
+			VEXUUID:             vexUUID,
+			VEXVersion:          sbomVersion,
 		})
 		g.SetAttestor(attestor)
 	}

--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -247,16 +247,15 @@ func action(cmd *cobra.Command, args []string) error {
 	var attestor *attestation.Builder
 	if attestEnabled {
 		attestor = attestation.NewBuilder(attestation.Opts{
-			VensVersion:         version.GetVersion(),
-			Provider:            provider,
-			Model:               model,
-			Seed:                o.Seed,
-			Temperature:         o.Temperature,
-			InputHash:           attestation.HashInput(inputB),
-			ConfigHash:          attestation.HashInput(cfgBytes),
-			PromptSchemaVersion: generator.PromptSchemaVersion,
-			VEXUUID:             vexUUID,
-			VEXVersion:          sbomVersion,
+			VensVersion: version.GetVersion(),
+			Provider:    provider,
+			Model:       model,
+			Seed:        o.Seed,
+			Temperature: o.Temperature,
+			InputHash:   attestation.HashInput(inputB),
+			ConfigHash:  attestation.HashInput(cfgBytes),
+			VEXUUID:     vexUUID,
+			VEXVersion:  sbomVersion,
 		})
 		g.SetAttestor(attestor)
 	}

--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -109,8 +109,12 @@ func action(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--config-file is required")
 	}
 
-	// Load config.yaml with context hints
-	cfg, cfgBytes, err := riskconfig.Load(configPath)
+	// Load config.yaml with context hints (read once so --attest can hash these bytes)
+	cfgBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %q: %w", configPath, err)
+	}
+	cfg, err := riskconfig.Parse(cfgBytes)
 	if err != nil {
 		return fmt.Errorf("failed to load config file %q: %w", configPath, err)
 	}

--- a/cmd/vens/testdata/script/generate_attest.txt
+++ b/cmd/vens/testdata/script/generate_attest.txt
@@ -20,18 +20,32 @@ json-contains output.attestation.cdx.json '"type": "bom"'
 # Producing tool version is recorded
 json-contains output.attestation.cdx.json '"name": "vens"'
 
-# Per-batch evidence carries the minimum reproducibility field set
+# Per-batch evidence carries the reproducibility field set
 json-contains output.attestation.cdx.json '"bom-ref": "evidence-batch-1"'
-json-contains output.attestation.cdx.json '"name": "prompt_hash"'
-json-contains output.attestation.cdx.json '"name": "input_hash"'
+json-contains output.attestation.cdx.json '"name": "generation_method"'
+json-contains output.attestation.cdx.json '"name": "provider"'
 json-contains output.attestation.cdx.json '"name": "model"'
 json-contains output.attestation.cdx.json '"name": "seed"'
+json-contains output.attestation.cdx.json '"name": "temperature"'
+json-contains output.attestation.cdx.json '"name": "prompt_hash"'
+json-contains output.attestation.cdx.json '"name": "input_hash"'
+json-contains output.attestation.cdx.json '"name": "config_hash"'
+json-contains output.attestation.cdx.json '"name": "prompt_schema_version"'
 json-contains output.attestation.cdx.json '"name": "raw_response"'
 json-contains output.attestation.cdx.json '"encoding": "base64"'
 
-# Evidence values, not just field names
-json-contains output.attestation.cdx.json '"content": "mock/mock"'
+# Evidence values: provider and model are separate fields, seed echoed
+json-contains output.attestation.cdx.json '"content": "mock"'
 json-contains output.attestation.cdx.json '"content": "7"'
+
+# One claim per CVE/component, with a deduped target, assessor and attestation
+json-contains output.attestation.cdx.json '"claims"'
+json-contains output.attestation.cdx.json '"bom-ref": "claim-1"'
+json-contains output.attestation.cdx.json '"predicate"'
+json-contains output.attestation.cdx.json '"name": "openssl"'
+json-contains output.attestation.cdx.json '"assessors"'
+json-contains output.attestation.cdx.json '"name": "vens automated assessment"'
+json-contains output.attestation.cdx.json '"attestations"'
 
 -- config.yaml --
 project:

--- a/cmd/vens/testdata/script/generate_attest.txt
+++ b/cmd/vens/testdata/script/generate_attest.txt
@@ -30,7 +30,6 @@ json-contains output.attestation.cdx.json '"name": "temperature"'
 json-contains output.attestation.cdx.json '"name": "prompt_hash"'
 json-contains output.attestation.cdx.json '"name": "input_hash"'
 json-contains output.attestation.cdx.json '"name": "config_hash"'
-json-contains output.attestation.cdx.json '"name": "prompt_schema_version"'
 json-contains output.attestation.cdx.json '"name": "raw_response"'
 json-contains output.attestation.cdx.json '"encoding": "base64"'
 

--- a/docs/reference/generate.md
+++ b/docs/reference/generate.md
@@ -176,13 +176,21 @@ vens generate --attest \
 # writes out.cdx.json AND out.attestation.cdx.json
 ```
 
-**Schema** (CDX 1.7 BOM, one `declarations.evidence[]` entry per LLM batch):
+**What it contains** (CDX 1.7 BOM, everything under `declarations`):
 
-- `prompt_hash` — SHA-256 of `system_prompt + "\n\n" + human_prompt`
-- `input_hash` — SHA-256 of the scanner input report bytes
-- `model` — the `<provider>/<model>` used for the run (e.g. `openai/gpt-4o`). When the provider's `*_MODEL` env var is unset, vens falls back to that provider's default model and logs it.
-- `seed` — the LLM seed (`0` if unset)
-- `raw_response` — base64-encoded raw LLM JSON response
+- `claims[]` — one per scored CVE/affected component: the assessment (`predicate` + `reasoning`), linked to its target component and to the evidence that backs it
+- `targets.components[]` — the affected components the claims point at
+- `evidence[]` — one per LLM batch, recording how the scoring was produced:
+    - `generation_method` — `llm`
+    - `provider` / `model` — backend and model used (e.g. `openai` / `gpt-4o`); when the provider's `*_MODEL` env var is unset, vens falls back to that provider's default and logs it
+    - `seed` — the LLM seed (`0` if unset)
+    - `temperature` — the sampling temperature
+    - `prompt_hash` — SHA-256 of `system_prompt + "\n\n" + human_prompt`
+    - `input_hash` — SHA-256 of the scanner report bytes
+    - `config_hash` — SHA-256 of the `config.yaml` used
+    - `prompt_schema_version` — version of the LLM output schema
+    - `raw_response` — base64-encoded raw LLM JSON reply (flagged `sensitiveData`)
+- `assessors[]` + `attestations[]` — tie the claims to vens as the producer; a human reviewer can later add their own assessor/attestation over the same claims without touching the LLM evidence
 
 The producing `vens` version is recorded in `metadata.tools`. The attestation is a `file` component that links to the VEX it describes through a `bom` external reference (`urn:cdx:<vex-serial>/<version>`).
 
@@ -190,7 +198,7 @@ The producing `vens` version is recorded in `metadata.tools`. The attestation is
     The attestation records the inputs and outputs of each LLM call. Recreating a score also requires the `config.yaml` used at the time — keep it under version control alongside the attestation.
 
 !!! warning "The attestation is sensitive — store it like audit evidence"
-    `raw_response` is **base64-encoded, not encrypted** — anyone with the file can decode it back to the model's reply: the CVE IDs you scored, their scores, and the free-text reasoning (which reflects your `config.yaml` context). The prompt and scanner report are stored only as SHA-256 hashes, so the raw vulnerability list and package versions are not embedded. In CI, write the attestation to the same access-controlled store as your other security evidence — not to a public build artifact.
+    The claims spell out, in clear text, which CVEs you scored, their scores and the model's reasoning, and `raw_response` holds the full model reply **base64-encoded, not encrypted** (anyone with the file can decode it). The prompt, scanner report and config are kept only as SHA-256 hashes, so the raw vulnerability list is not embedded, but the assessment itself is fully readable. In CI, write the attestation to the same access-controlled store as your other security evidence, not to a public build artifact.
 
 ### `--sbom-version <int>`
 

--- a/docs/reference/generate.md
+++ b/docs/reference/generate.md
@@ -188,7 +188,6 @@ vens generate --attest \
     - `prompt_hash` — SHA-256 of `system_prompt + "\n\n" + human_prompt`
     - `input_hash` — SHA-256 of the scanner report bytes
     - `config_hash` — SHA-256 of the `config.yaml` used
-    - `prompt_schema_version` — version of the LLM output schema
     - `raw_response` — base64-encoded raw LLM JSON reply (flagged `sensitiveData`)
 - `assessors[]` + `attestations[]` — tie the claims to vens as the producer; a human reviewer can later add their own assessor/attestation over the same claims without touching the LLM evidence
 

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package attestation builds the CycloneDX Attestations (CDXA) sibling file for
-// a vens VEX: prompt hash, input hash, model, seed, raw LLM response.
+// a vens VEX: per-CVE claims backed by per-batch LLM evidence.
 package attestation
 
 import (
@@ -31,27 +31,50 @@ import (
 
 // Opts configures a Builder. Set once per run.
 type Opts struct {
-	VensVersion string
-	Provider    string
-	Model       string
-	Seed        int
-	InputHash   string
-	VEXUUID     string
-	VEXVersion  int
-	Now         func() time.Time
+	VensVersion         string
+	Provider            string
+	Model               string
+	Seed                int
+	Temperature         float64
+	InputHash           string
+	ConfigHash          string
+	PromptSchemaVersion string
+	VEXUUID             string
+	VEXVersion          int
+	Now                 func() time.Time
 }
 
-// Builder collects per-batch evidence and emits a CDX 1.7 BOM with
-// declarations.evidence[].
+// ClaimInput is one scored CVE/component assessment to attest.
+type ClaimInput struct {
+	VulnID      string
+	CompRef     string
+	CompName    string
+	CompVersion string
+	PURL        string
+	Score       float64
+	Severity    string
+	Reasoning   string
+}
+
+// Builder collects per-batch evidence and per-CVE claims, then emits a CDX 1.7
+// BOM with declarations (targets, claims, evidence, assessor, attestation).
 type Builder struct {
-	opts    Opts
-	batches []batchEvidence
+	opts       Opts
+	batches    []batchEvidence
+	claims     []claimEntry
+	targets    []cyclonedx.Component
+	seenTarget map[string]bool
 }
 
 type batchEvidence struct {
 	promptHash  string
 	rawResponse []byte
 	at          time.Time
+}
+
+type claimEntry struct {
+	in          ClaimInput
+	evidenceRef string
 }
 
 // HashInput returns the hex-encoded SHA-256 of b.
@@ -73,19 +96,44 @@ func NewBuilder(opts Opts) *Builder {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
-	return &Builder{opts: opts}
+	return &Builder{opts: opts, seenTarget: map[string]bool{}}
 }
 
-// AddBatch records evidence for a single LLM batch. systemPrompt and humanPrompt
-// are hashed together (SHA-256 of system + "\n\n" + human); rawResponse is the
-// raw bytes returned by the LLM.
-func (b *Builder) AddBatch(systemPrompt, humanPrompt string, rawResponse []byte) {
+// AddBatch records evidence for a single LLM batch and returns its bom-ref, so
+// claims from the same batch can point at it. systemPrompt and humanPrompt are
+// hashed together (SHA-256 of system + "\n\n" + human); rawResponse is the raw
+// bytes returned by the LLM.
+func (b *Builder) AddBatch(systemPrompt, humanPrompt string, rawResponse []byte) string {
 	sum := sha256.Sum256([]byte(systemPrompt + "\n\n" + humanPrompt))
 	b.batches = append(b.batches, batchEvidence{
 		promptHash:  hex.EncodeToString(sum[:]),
 		rawResponse: append([]byte(nil), rawResponse...),
 		at:          b.opts.Now().UTC(),
 	})
+	return fmt.Sprintf("evidence-batch-%d", len(b.batches))
+}
+
+// AddClaim records one assessment (a scored CVE on a component) backed by the
+// given evidence. The component is added to the target list once.
+func (b *Builder) AddClaim(evidenceRef string, c ClaimInput) {
+	if c.CompRef == "" {
+		return // a claim must resolve to a target component
+	}
+	b.claims = append(b.claims, claimEntry{in: c, evidenceRef: evidenceRef})
+	if b.seenTarget[c.CompRef] {
+		return
+	}
+	b.seenTarget[c.CompRef] = true
+	comp := cyclonedx.Component{
+		BOMRef:  c.CompRef,
+		Type:    cyclonedx.ComponentTypeLibrary,
+		Name:    c.CompName,
+		Version: c.CompVersion,
+	}
+	if strings.HasPrefix(c.PURL, "pkg:") {
+		comp.PackageURL = c.PURL
+	}
+	b.targets = append(b.targets, comp)
 }
 
 // BatchCount returns the number of batches recorded.
@@ -135,31 +183,11 @@ func (b *Builder) Write(w io.Writer) error {
 		}
 	}
 
-	// "provider/model", or just whichever part is set (no dangling slash).
-	model := b.opts.Model
-	switch {
-	case b.opts.Provider != "" && model != "":
-		model = b.opts.Provider + "/" + model
-	case model == "":
-		model = b.opts.Provider
+	decl := &cyclonedx.Declarations{Evidence: b.evidence()}
+	if len(b.claims) > 0 {
+		b.addClaims(decl)
 	}
-	evidence := make([]cyclonedx.DeclarationEvidence, 0, len(b.batches))
-	for i, e := range b.batches {
-		data := []cyclonedx.EvidenceData{
-			textData("prompt_hash", e.promptHash),
-			textData("input_hash", b.opts.InputHash),
-			textData("model", model),
-			textData("seed", fmt.Sprintf("%d", b.opts.Seed)),
-			base64Data("raw_response", e.rawResponse, "application/json"),
-		}
-		evidence = append(evidence, cyclonedx.DeclarationEvidence{
-			BOMRef:      fmt.Sprintf("evidence-batch-%d", i+1),
-			Description: fmt.Sprintf("LLM scoring batch %d", i+1),
-			Created:     e.at.Format(time.RFC3339),
-			Data:        &data,
-		})
-	}
-	bom.Declarations = &cyclonedx.Declarations{Evidence: &evidence}
+	bom.Declarations = decl
 
 	enc := cyclonedx.NewBOMEncoder(w, cyclonedx.BOMFileFormatJSON)
 	enc.SetPretty(true)
@@ -167,6 +195,73 @@ func (b *Builder) Write(w io.Writer) error {
 		return fmt.Errorf("attestation: encode: %w", err)
 	}
 	return nil
+}
+
+// evidence builds one declarations.evidence entry per LLM batch.
+func (b *Builder) evidence() *[]cyclonedx.DeclarationEvidence {
+	out := make([]cyclonedx.DeclarationEvidence, 0, len(b.batches))
+	for i, e := range b.batches {
+		data := []cyclonedx.EvidenceData{
+			textData("generation_method", "llm"),
+			textData("provider", b.opts.Provider),
+			textData("model", b.opts.Model),
+			textData("seed", fmt.Sprintf("%d", b.opts.Seed)),
+			textData("temperature", fmt.Sprintf("%g", b.opts.Temperature)),
+			textData("prompt_hash", e.promptHash),
+			textData("input_hash", b.opts.InputHash),
+		}
+		if b.opts.ConfigHash != "" {
+			data = append(data, textData("config_hash", b.opts.ConfigHash))
+		}
+		if b.opts.PromptSchemaVersion != "" {
+			data = append(data, textData("prompt_schema_version", b.opts.PromptSchemaVersion))
+		}
+		raw := base64Data("raw_response", e.rawResponse, "application/json")
+		raw.SensitiveData = &[]string{"raw LLM output, may echo SBOM-derived context"}
+		data = append(data, raw)
+
+		out = append(out, cyclonedx.DeclarationEvidence{
+			BOMRef:      fmt.Sprintf("evidence-batch-%d", i+1),
+			Description: fmt.Sprintf("LLM scoring batch %d", i+1),
+			Created:     e.at.Format(time.RFC3339),
+			Data:        &data,
+		})
+	}
+	return &out
+}
+
+// addClaims fills assessor, targets, claims and the attestation that maps them.
+func (b *Builder) addClaims(decl *cyclonedx.Declarations) {
+	const assessorRef cyclonedx.BOMReference = "assessor-vens"
+
+	decl.Assessors = &[]cyclonedx.Assessor{{
+		BOMRef:       assessorRef,
+		Organization: &cyclonedx.OrganizationalEntity{Name: "vens automated assessment"},
+	}}
+	if len(b.targets) > 0 {
+		targets := b.targets
+		decl.Targets = &cyclonedx.Targets{Components: &targets}
+	}
+
+	claims := make([]cyclonedx.Claim, 0, len(b.claims))
+	refs := make([]cyclonedx.BOMReference, 0, len(b.claims))
+	for i, c := range b.claims {
+		ref := fmt.Sprintf("claim-%d", i+1)
+		claims = append(claims, cyclonedx.Claim{
+			BOMRef:    ref,
+			Target:    cyclonedx.BOMReference(c.in.CompRef),
+			Predicate: fmt.Sprintf("%s on %s %s assessed at OWASP risk %.2f (%s)", c.in.VulnID, c.in.CompName, c.in.CompVersion, c.in.Score, c.in.Severity),
+			Reasoning: c.in.Reasoning,
+			Evidence:  &[]cyclonedx.BOMReference{cyclonedx.BOMReference(c.evidenceRef)},
+		})
+		refs = append(refs, cyclonedx.BOMReference(ref))
+	}
+	decl.Claims = &claims
+	decl.Attestations = &[]cyclonedx.Attestation{{
+		Summary:  "OWASP risk scores generated by vens via an LLM, one claim per CVE/component.",
+		Assessor: assessorRef,
+		Map:      &[]cyclonedx.AttestationMap{{Claims: &refs}},
+	}}
 }
 
 func textData(name, value string) cyclonedx.EvidenceData {

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -31,17 +31,16 @@ import (
 
 // Opts configures a Builder. Set once per run.
 type Opts struct {
-	VensVersion         string
-	Provider            string
-	Model               string
-	Seed                int
-	Temperature         float64
-	InputHash           string
-	ConfigHash          string
-	PromptSchemaVersion string
-	VEXUUID             string
-	VEXVersion          int
-	Now                 func() time.Time
+	VensVersion string
+	Provider    string
+	Model       string
+	Seed        int
+	Temperature float64
+	InputHash   string
+	ConfigHash  string
+	VEXUUID     string
+	VEXVersion  int
+	Now         func() time.Time
 }
 
 // ClaimInput is one scored CVE/component assessment to attest.
@@ -212,9 +211,6 @@ func (b *Builder) evidence() *[]cyclonedx.DeclarationEvidence {
 		}
 		if b.opts.ConfigHash != "" {
 			data = append(data, textData("config_hash", b.opts.ConfigHash))
-		}
-		if b.opts.PromptSchemaVersion != "" {
-			data = append(data, textData("prompt_schema_version", b.opts.PromptSchemaVersion))
 		}
 		raw := base64Data("raw_response", e.rawResponse, "application/json")
 		raw.SensitiveData = &[]string{"raw LLM output, may echo SBOM-derived context"}

--- a/pkg/attestation/attestation_test.go
+++ b/pkg/attestation/attestation_test.go
@@ -174,7 +174,9 @@ func TestBuilder_Write_StructureAndFields(t *testing.T) {
 	wantPrompt := sha256.Sum256([]byte("sys\n\nhum"))
 	assert.Equal(t, hex.EncodeToString(wantPrompt[:]), fields["prompt_hash"])
 	assert.Equal(t, HashInput([]byte(`{"hello":"world"}`)), fields["input_hash"])
-	assert.Equal(t, "openai/gpt-4o", fields["model"])
+	assert.Equal(t, "gpt-4o", fields["model"])
+	assert.Equal(t, "openai", fields["provider"])
+	assert.Equal(t, "llm", fields["generation_method"])
 	assert.Equal(t, "42", fields["seed"])
 
 	gotResp, err := base64.StdEncoding.DecodeString(fields["raw_response"])
@@ -197,21 +199,24 @@ func TestBuilder_Write_NoVEXUUID_NoComponent(t *testing.T) {
 	assert.Nil(t, got.Metadata.Component, "metadata.component should be omitted when VEXUUID empty")
 }
 
-func TestBuilder_Write_ProviderEmpty_ModelStandsAlone(t *testing.T) {
-	b := newTestBuilder(t, func(o *Opts) { o.Provider = "" })
+func TestBuilder_Write_ProviderAndModelSeparate(t *testing.T) {
+	b := newTestBuilder(t, nil)
 	b.AddBatch("s", "h", []byte("{}"))
 	var buf bytes.Buffer
 	require.NoError(t, b.Write(&buf))
-	assert.Equal(t, "gpt-4o", evidenceFields(t, buf.Bytes())["model"])
+	f := evidenceFields(t, buf.Bytes())
+	assert.Equal(t, "openai", f["provider"])
+	assert.Equal(t, "gpt-4o", f["model"])
 }
 
-func TestBuilder_Write_ModelEmpty_ProviderStandsAlone(t *testing.T) {
+func TestBuilder_Write_ModelEmpty_ProviderStillRecorded(t *testing.T) {
 	b := newTestBuilder(t, func(o *Opts) { o.Model = "" })
 	b.AddBatch("s", "h", []byte("{}"))
 	var buf bytes.Buffer
 	require.NoError(t, b.Write(&buf))
-	// An unset model must not produce a dangling "provider/".
-	assert.Equal(t, "openai", evidenceFields(t, buf.Bytes())["model"])
+	f := evidenceFields(t, buf.Bytes())
+	assert.Equal(t, "", f["model"])
+	assert.Equal(t, "openai", f["provider"])
 }
 
 func TestBuilder_Write_MultipleBatches(t *testing.T) {
@@ -225,6 +230,97 @@ func TestBuilder_Write_MultipleBatches(t *testing.T) {
 	for _, want := range []string{"evidence-batch-1", "evidence-batch-2", "evidence-batch-3"} {
 		assert.Contains(t, s, want)
 	}
+}
+
+func TestBuilder_Write_Claims(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	ref := b.AddBatch("sys", "hum", []byte(`{"results":[]}`))
+	openssl := ClaimInput{
+		VulnID: "CVE-2024-1234", CompRef: "pkg:deb/debian/openssl@3.0.11",
+		CompName: "openssl", CompVersion: "3.0.11", PURL: "pkg:deb/debian/openssl@3.0.11",
+		Score: 56, Severity: "high", Reasoning: "RCE",
+	}
+	b.AddClaim(ref, openssl)
+	// Same component, second CVE: one more claim, but no duplicate target.
+	second := openssl
+	second.VulnID = "CVE-2024-5678"
+	second.Reasoning = "DoS"
+	b.AddClaim(ref, second)
+
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+
+	var got struct {
+		Declarations struct {
+			Assessors []struct {
+				BomRef       string `json:"bom-ref"`
+				Organization struct {
+					Name string `json:"name"`
+				} `json:"organization"`
+			} `json:"assessors"`
+			Targets struct {
+				Components []struct {
+					BomRef string `json:"bom-ref"`
+					Name   string `json:"name"`
+					Purl   string `json:"purl"`
+				} `json:"components"`
+			} `json:"targets"`
+			Claims []struct {
+				BomRef    string   `json:"bom-ref"`
+				Target    string   `json:"target"`
+				Predicate string   `json:"predicate"`
+				Reasoning string   `json:"reasoning"`
+				Evidence  []string `json:"evidence"`
+			} `json:"claims"`
+			Attestations []struct {
+				Assessor string `json:"assessor"`
+				Map      []struct {
+					Claims []string `json:"claims"`
+				} `json:"map"`
+			} `json:"attestations"`
+		} `json:"declarations"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got), "output:\n%s", buf.String())
+	d := got.Declarations
+
+	require.Len(t, d.Claims, 2)
+	require.Len(t, d.Targets.Components, 1, "same component must be deduped")
+	require.Len(t, d.Assessors, 1)
+	require.Len(t, d.Attestations, 1)
+
+	assert.Equal(t, "pkg:deb/debian/openssl@3.0.11", d.Targets.Components[0].BomRef)
+	assert.Equal(t, "openssl", d.Targets.Components[0].Name)
+	assert.Equal(t, "pkg:deb/debian/openssl@3.0.11", d.Targets.Components[0].Purl)
+
+	c0 := d.Claims[0]
+	assert.Equal(t, "pkg:deb/debian/openssl@3.0.11", c0.Target)
+	assert.Contains(t, c0.Predicate, "CVE-2024-1234")
+	assert.Equal(t, "RCE", c0.Reasoning)
+	require.Len(t, c0.Evidence, 1)
+	assert.Equal(t, ref, c0.Evidence[0], "claim points at its batch evidence")
+
+	at := d.Attestations[0]
+	assert.Equal(t, d.Assessors[0].BomRef, at.Assessor)
+	require.Len(t, at.Map, 1)
+	assert.ElementsMatch(t, []string{d.Claims[0].BomRef, d.Claims[1].BomRef}, at.Map[0].Claims)
+}
+
+func TestBuilder_AddClaim_EmptyCompRefSkipped(t *testing.T) {
+	b := newTestBuilder(t, nil)
+	ref := b.AddBatch("s", "h", []byte("{}"))
+	b.AddClaim(ref, ClaimInput{VulnID: "CVE-X", Score: 1, Severity: "info"}) // no CompRef
+
+	var buf bytes.Buffer
+	require.NoError(t, b.Write(&buf))
+	var got struct {
+		Declarations struct {
+			Claims  *[]json.RawMessage `json:"claims"`
+			Targets *json.RawMessage   `json:"targets"`
+		} `json:"declarations"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Nil(t, got.Declarations.Claims, "a claim with no component ref must be skipped")
+	assert.Nil(t, got.Declarations.Targets)
 }
 
 func TestSiblingPath(t *testing.T) {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -90,6 +90,10 @@ type llmOutput struct {
 	Results []llmOutputEntry `json:"results"`
 }
 
+// PromptSchemaVersion identifies the LLM output schema. Bump it when the schema
+// or scoring prompt changes in a way that affects reproducibility.
+const PromptSchemaVersion = "1"
+
 // Opts configures the Generator.
 type Opts struct {
 	LLM         llms.Model
@@ -177,7 +181,7 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 	}
 
 	// Call LLM to calculate OWASP scores for each vulnerability
-	scores, err := g.evaluateOWASPScores(ctx, llmBatch)
+	scores, evidenceRef, err := g.evaluateOWASPScores(ctx, llmBatch)
 	if err != nil {
 		return fmt.Errorf("LLM evaluation failed: %w", err)
 	}
@@ -241,6 +245,20 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 			},
 			Source: source,
 		})
+
+		if g.attestor != nil {
+			v := vulnMap[entry.VulnID]
+			g.attestor.AddClaim(evidenceRef, attestation.ClaimInput{
+				VulnID:      entry.VulnID,
+				CompRef:     v.BOMRef,
+				CompName:    v.PkgName,
+				CompVersion: v.InstalledVersion,
+				PURL:        v.BOMRef,
+				Score:       score,
+				Severity:    severity,
+				Reasoning:   entry.Reasoning,
+			})
+		}
 	}
 
 	if len(group) == 0 {
@@ -254,9 +272,9 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 
 // evaluateOWASPScores calls the LLM to calculate the OWASP risk score for each vulnerability.
 // The LLM uses the project context hints to determine the appropriate score.
-func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerability) ([]llmOutputEntry, error) {
+func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerability) ([]llmOutputEntry, string, error) {
 	if g.o.LLM == nil {
-		return nil, errors.New("no LLM configured")
+		return nil, "", errors.New("no LLM configured")
 	}
 
 	var buf bytes.Buffer
@@ -284,7 +302,7 @@ func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerab
 	schema := g.buildOutputSchema()
 	schemaJ, err := schema.MarshalJSON()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	systemPrompt += "#### Output format: JSON Schema\n"
@@ -299,7 +317,7 @@ func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerab
 	// Build human prompt with vulnerabilities
 	vulnsJSON, err := json.Marshal(vulns)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal vulnerabilities: %w", err)
+		return nil, "", fmt.Errorf("failed to marshal vulnerabilities: %w", err)
 	}
 	humanPrompt := string(vulnsJSON)
 
@@ -324,17 +342,18 @@ func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerab
 		_, err := g.o.LLM.GenerateContent(c, msgs, callOpts...)
 		return err
 	}); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
+	var evidenceRef string
 	if g.attestor != nil {
-		g.attestor.AddBatch(systemPrompt, humanPrompt, buf.Bytes())
+		evidenceRef = g.attestor.AddBatch(systemPrompt, humanPrompt, buf.Bytes())
 	}
 
 	// Parse LLM response
 	var resp llmOutput
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse LLM output: %w: %q", err, buf.String())
+		return nil, "", fmt.Errorf("unable to parse LLM output: %w: %q", err, buf.String())
 	}
 
 	// Calculate final OWASP scores in Go for mathematical accuracy
@@ -358,7 +377,7 @@ func (g *Generator) evaluateOWASPScores(ctx context.Context, vulns []LLMVulnerab
 		)
 	}
 
-	return resp.Results, nil
+	return resp.Results, evidenceRef, nil
 }
 
 // buildSystemPrompt creates the system prompt for OWASP score calculation.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -90,10 +90,6 @@ type llmOutput struct {
 	Results []llmOutputEntry `json:"results"`
 }
 
-// PromptSchemaVersion identifies the LLM output schema. Bump it when the schema
-// or scoring prompt changes in a way that affects reproducibility.
-const PromptSchemaVersion = "1"
-
 // Opts configures the Generator.
 type Opts struct {
 	LLM         llms.Model

--- a/pkg/riskconfig/config.go
+++ b/pkg/riskconfig/config.go
@@ -140,23 +140,24 @@ var (
 	}
 )
 
-// Load parses a config.yaml file from the given path and validates entries.
-func Load(path string) (*Config, error) {
+// Load parses a config.yaml file from the given path, validates entries, and
+// returns the raw file bytes so callers can hash exactly what was read.
+func Load(path string) (*Config, []byte, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var cfg Config
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate context hints
 	if err := cfg.validate(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &cfg, nil
+	return &cfg, b, nil
 }
 
 // validate checks that all context hints have valid values and applies defaults.

--- a/pkg/riskconfig/config.go
+++ b/pkg/riskconfig/config.go
@@ -16,7 +16,6 @@ package riskconfig
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -140,24 +139,19 @@ var (
 	}
 )
 
-// Load parses a config.yaml file from the given path, validates entries, and
-// returns the raw file bytes so callers can hash exactly what was read.
-func Load(path string) (*Config, []byte, error) {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return nil, nil, err
-	}
+// Parse unmarshals raw YAML bytes into a Config, then validates it.
+func Parse(b []byte) (*Config, error) {
 	var cfg Config
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Validate context hints
 	if err := cfg.validate(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &cfg, b, nil
+	return &cfg, nil
 }
 
 // validate checks that all context hints have valid values and applies defaults.


### PR DESCRIPTION
Step 2 of #138, on top of the merged #148. Per scored CVE/component vens now emits a CDXA claim (predicate + reasoning) linked to its target and the evidence batch that produced it, plus a single assessor + attestation. Evidence is enriched with separate provider/model, temperature, config_hash and prompt_schema_version.

Tests + testscript updated, docs refreshed. A mock-generated example matches the shape agreed on #138.
