### PR TITLE
fix: keep every component when a CVE affects several in one batch

### DIFF
--- a/cmd/vens/testdata/script/generate_dup_cve.txt
+++ b/cmd/vens/testdata/script/generate_dup_cve.txt
@@ -1,0 +1,57 @@
+# Regression: the same CVE on two components must not collapse onto one.
+# The VEX must reference both affected components, and the attestation must
+# carry one claim per component with two distinct targets.
+
+exec vens generate --llm=mock --attest --config-file=config.yaml --sbom-serial-number=urn:uuid:11111111-1111-1111-1111-111111111111 report.json output.cdx.json
+stderr 'Processing vulnerabilities'
+
+# VEX references both affected components
+json-contains output.cdx.json 'pkg:deb/debian/openssl@3.0.11'
+json-contains output.cdx.json 'pkg:deb/debian/libssl3@3.0.11'
+
+# Attestation: one claim per component, two distinct targets
+json-contains output.attestation.cdx.json '"bom-ref": "claim-1"'
+json-contains output.attestation.cdx.json '"bom-ref": "claim-2"'
+json-contains output.attestation.cdx.json '"target": "pkg:deb/debian/openssl@3.0.11"'
+json-contains output.attestation.cdx.json '"target": "pkg:deb/debian/libssl3@3.0.11"'
+
+-- config.yaml --
+project:
+  name: "dup-cve-test"
+  description: "Same CVE across two components"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+-- report.json --
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2026-06-11T10:00:00Z",
+  "ArtifactName": "demo",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "demo (debian 12)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-1234",
+          "PkgName": "openssl",
+          "InstalledVersion": "3.0.11",
+          "Severity": "HIGH",
+          "Title": "Same CVE, first component",
+          "PkgIdentifier": { "PURL": "pkg:deb/debian/openssl@3.0.11" }
+        },
+        {
+          "VulnerabilityID": "CVE-2024-1234",
+          "PkgName": "libssl3",
+          "InstalledVersion": "3.0.11",
+          "Severity": "HIGH",
+          "Title": "Same CVE, second component",
+          "PkgIdentifier": { "PURL": "pkg:deb/debian/libssl3@3.0.11" }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -160,10 +160,12 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 		return errors.New("config not initialized; load config.yaml first")
 	}
 
-	vulnMap := make(map[string]Vulnerability, len(vulnBatch))
+	// A CVE can affect several components in one batch, so group every component
+	// under its VulnID. Keying by VulnID alone would keep only the last one.
+	vulnsByID := make(map[string][]Vulnerability, len(vulnBatch))
 	llmBatch := make([]LLMVulnerability, len(vulnBatch))
 	for i, v := range vulnBatch {
-		vulnMap[v.VulnID] = v
+		vulnsByID[v.VulnID] = append(vulnsByID[v.VulnID], v)
 		llmBatch[i] = LLMVulnerability{
 			VulnID:           v.VulnID,
 			PkgID:            v.PkgID,
@@ -182,12 +184,14 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 		return fmt.Errorf("LLM evaluation failed: %w", err)
 	}
 
-	// Build VulnRating group using Go-calculated scores
+	// Build VulnRating group using Go-calculated scores.
 	group := make([]outputhandler.VulnRating, 0, len(vulnBatch))
+	scored := make(map[string]bool)
 	for _, entry := range scores {
-		if entry.VulnID == "" {
+		if entry.VulnID == "" || scored[entry.VulnID] {
 			continue
 		}
+		scored[entry.VulnID] = true
 
 		// Calculate final OWASP score using the formula:
 		// Risk = Likelihood × Impact = ((ThreatAgent + Vulnerability)/2) × ((TechImpact + BusinessImpact)/2)
@@ -207,53 +211,55 @@ func (g *Generator) generateRiskScore(ctx context.Context, vulnBatch []Vulnerabi
 		)
 		vectorString := vector.String()
 
-		bomRef := ""
-		if v, ok := vulnMap[entry.VulnID]; ok {
-			bomRef = v.BOMRef
+		comps := vulnsByID[entry.VulnID]
+		if len(comps) == 0 {
+			// Keep one rating even when the CVE isn't in the batch map (unchanged).
+			comps = []Vulnerability{{VulnID: entry.VulnID}}
 		}
+		for _, v := range comps {
+			slog.InfoContext(ctx, "Scored vulnerability",
+				"vuln", entry.VulnID,
+				"pkg", v.BOMRef,
+				"score", fmt.Sprintf("%.1f", score),
+				"severity", severity,
+				"vector", vectorString,
+			)
 
-		slog.InfoContext(ctx, "Scored vulnerability",
-			"vuln", entry.VulnID,
-			"pkg", bomRef,
-			"score", fmt.Sprintf("%.1f", score),
-			"severity", severity,
-			"vector", vectorString,
-		)
-
-		var source *cyclonedx.Source
-		if v, ok := vulnMap[entry.VulnID]; ok && v.SourceName != "" {
-			source = &cyclonedx.Source{
-				Name: v.SourceName,
-				URL:  v.SourceURL,
+			var source *cyclonedx.Source
+			if v.SourceName != "" {
+				source = &cyclonedx.Source{
+					Name: v.SourceName,
+					URL:  v.SourceURL,
+				}
+			} else {
+				source = vuln.Source(entry.VulnID)
 			}
-		} else {
-			source = vuln.Source(entry.VulnID)
-		}
 
-		group = append(group, outputhandler.VulnRating{
-			VulnID: entry.VulnID,
-			BOMRef: bomRef,
-			Rating: cyclonedx.VulnerabilityRating{
-				Method:   cyclonedx.ScoringMethodOWASP,
-				Score:    &score,
-				Severity: cyclonedx.Severity(severity),
-				Vector:   vectorString,
-			},
-			Source: source,
-		})
-
-		if g.attestor != nil {
-			v := vulnMap[entry.VulnID]
-			g.attestor.AddClaim(evidenceRef, attestation.ClaimInput{
-				VulnID:      entry.VulnID,
-				CompRef:     v.BOMRef,
-				CompName:    v.PkgName,
-				CompVersion: v.InstalledVersion,
-				PURL:        v.BOMRef,
-				Score:       score,
-				Severity:    severity,
-				Reasoning:   entry.Reasoning,
+			s := score
+			group = append(group, outputhandler.VulnRating{
+				VulnID: entry.VulnID,
+				BOMRef: v.BOMRef,
+				Rating: cyclonedx.VulnerabilityRating{
+					Method:   cyclonedx.ScoringMethodOWASP,
+					Score:    &s,
+					Severity: cyclonedx.Severity(severity),
+					Vector:   vectorString,
+				},
+				Source: source,
 			})
+
+			if g.attestor != nil {
+				g.attestor.AddClaim(evidenceRef, attestation.ClaimInput{
+					VulnID:      entry.VulnID,
+					CompRef:     v.BOMRef,
+					CompName:    v.PkgName,
+					CompVersion: v.InstalledVersion,
+					PURL:        v.BOMRef,
+					Score:       score,
+					Severity:    severity,
+					Reasoning:   entry.Reasoning,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
A CVE affecting several packages in one batch collapsed onto the last one: scoring was keyed by VulnID alone. The VEX only listed the last affected component, and since #154 the CDXA claims did the same.

Fix: group components by VulnID and emit one rating and one claim per component. Regression test: same CVE on two packages gives two affects and two claims.

Surfaced during the #154 review. (thanks to @Mehrn0ush) 
