### PR TITLE
docs: document the --attest attestation (README + data flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Output is a [CycloneDX VEX](https://cyclonedx.org/capabilities/vex/) document; e
 }
 ```
 
-The per-CVE reasoning from the LLM is logged to stderr as the command runs, and is captured alongside prompts/responses when you pass `--debug-dir <path>`. It is intentionally not embedded in the VEX file to keep the document strictly CycloneDX-compliant.
+The per-CVE reasoning from the LLM is logged to stderr as the command runs, and is captured alongside prompts/responses when you pass `--debug-dir <path>`. It is intentionally not embedded in the VEX file to keep the document strictly CycloneDX-compliant. For a durable, auditable record of how each CVE was scored, pass `--attest` to also write a CycloneDX attestation next to the VEX.
 
 ## Configuration
 
@@ -142,6 +142,7 @@ vens generate --config-file config.yaml INPUT OUTPUT
 - `--llm` - LLM provider: `openai` | `anthropic` | `ollama` | `googleai` (default: `auto`)
 - `--llm-batch-size` - CVEs per request (default: `10`)
 - `--debug-dir` - Save prompts/responses for debugging
+- `--attest` - Emit a CycloneDX attestation sidecar recording how each CVE was scored (model, seed, prompt/input/config hashes, reasoning, raw response) for audit and reproduction
 
 ### `vens enrich`
 

--- a/docs/concepts/privacy-and-data-flow.md
+++ b/docs/concepts/privacy-and-data-flow.md
@@ -104,6 +104,12 @@ These files contain exactly the same data the LLM receives. They are useful for 
 
 Store it accordingly. See [`--debug-dir`](../reference/generate.md#--debug-dir-path) for retention guidance.
 
+## Attestation file
+
+When you pass `--attest`, Vens writes a CycloneDX attestation next to the VEX (`<output>.attestation.cdx.json`). Per scored CVE it records the model and seed, SHA-256 hashes of the prompt, scanner report and `config.yaml`, and the **raw LLM response** (base64, not encrypted).
+
+The hashes are opaque, but the claims state the CVEs you scored and the model's reasoning in clear text, and the raw response can echo SBOM-derived context. So it carries the same sensitivity as the debug output: treat it as security evidence, keep it access-controlled, and out of public build artifacts. See [`--attest`](../reference/generate.md#--attest).
+
 ---
 
 ## See also


### PR DESCRIPTION
`--attest` (the CDXA provenance sidecar) merged via #148/#154/#155 but the README never mentioned it, and the privacy/data-flow page didn't cover the file it writes.

- README: add `--attest` to the generate flags, and point the "where does the reasoning go" note at it.
- privacy-and-data-flow: new "Attestation file" section (it writes the raw LLM response, treat as sensitive).

Doc-only, ahead of the v0.4.0 release.
