### PR TITLE
docs: bump vens-action examples to v0.2.0 and document attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OWASP scoring (`Risk = Likelihood × Impact`, 0-81) reflects your system's expos
 
 **[GitHub Action](https://github.com/marketplace/actions/vens-action):**
 ```yaml
-- uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag; pin by SHA in production
+- uses: venslabs/vens-action@v0.2.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
     version: v0.3.2                   # vens binary version
     config-file: .vens/config.yaml    # see docs/guides/configuration.md to author this file

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -18,6 +18,8 @@ Mitigations Vens applies:
 
 If you need strict reproducibility for audit evidence at a point in time, pin a local Ollama model tag (model tags are immutable on disk) and archive `--debug-dir` output alongside the VEX. Together they give you a byte-exact record.
 
+You can also pass [`--attest`](../reference/generate.md#--attest) to write a CDXA sidecar that records, per CVE, the model, seed, temperature, and SHA-256 hashes of the prompt, scan report and `config.yaml`, plus the raw response. It captures the evidence to reproduce a run later. It is point-in-time evidence, not a cryptographic signature.
+
 ---
 
 ## 2. No published benchmark or calibration study
@@ -51,7 +53,7 @@ The CycloneDX VEX spec allows per-vulnerability `analysis.state`, `analysis.just
 - The LLM reasoning is not stable enough across runs to be embedded as a durable CycloneDX `justification` — that field is intended for human assertions.
 - Keeping the VEX strictly to numeric scoring means downstream tools can ingest it without trust assumptions about free-text fields.
 
-If you need a justification record (for audit), use `--debug-dir` and preserve the output alongside your evidence. See [`--debug-dir`](../reference/generate.md#--debug-dir-path).
+If you need a justification record (for audit), use `--debug-dir`, or pass [`--attest`](../reference/generate.md#--attest) to capture the per-CVE reasoning as structured CDXA claims (predicate plus reasoning) in a sidecar file, kept out of the VEX so downstream tools still ingest a clean document. See [`--debug-dir`](../reference/generate.md#--debug-dir-path).
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ If you scan with Trivy or Grype in GitHub Actions, drop [`venslabs/vens-action`]
   run: trivy image python:3.11-slim --format json --output report.json
 
 - name: Prioritize with vens
-  uses: venslabs/vens-action@v0.1.0   # check the marketplace for the latest tag; pin by SHA in production
+  uses: venslabs/vens-action@v0.2.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
     version: v0.3.2                   # vens binary version
     config-file: .vens/config.yaml    # see ../guides/configuration.md to author this file

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -12,7 +12,7 @@ Add this to your workflow after a container or dependency scan:
 
 - name: Prioritize with vens
   id: vens
-  uses: venslabs/vens-action@v0.1.0
+  uses: venslabs/vens-action@v0.2.0
   with:
     version: v0.3.2
     config-file: .vens/config.yaml
@@ -32,7 +32,7 @@ Add this to your workflow after a container or dependency scan:
       ${{ steps.vens.outputs.enriched-report }}
 ```
 
-For tighter supply-chain control, pin by commit SHA instead of the mutable tag: `uses: venslabs/vens-action@5e8b440b...  # v0.1.0`. Dependabot and Renovate both track SHA-pinned actions.
+For tighter supply-chain control, pin by commit SHA instead of the mutable tag: `uses: venslabs/vens-action@06d3eb97fb0c2040e95f3bea271d0aeb2fd00c76  # v0.2.0`. Dependabot and Renovate both track SHA-pinned actions.
 
 ## About vens-action
 
@@ -42,12 +42,34 @@ Key difference from running `vens generate` directly: the action handles binary 
 
 The `llm-api-key` is passed as an environment variable (never a CLI argument) and masked in workflow logs via `::add-mask::` before any step runs.
 
+## Attestation
+
+Set `attest: "true"` to also emit a [CycloneDX Attestations (CDXA)](https://cyclonedx.org/capabilities/attestations/) file next to the VEX, recording how each CVE was scored (model, seed, prompt/input/config hashes, raw LLM response) for audit and reproduction. Its path is exposed as the `attestation-file` output:
+
+```yaml
+- name: Prioritize with vens
+  id: vens
+  uses: venslabs/vens-action@v0.2.0
+  with:
+    # ...usual inputs...
+    attest: "true"
+
+- uses: actions/upload-artifact@v4
+  with:
+    name: vens-output
+    path: |
+      ${{ steps.vens.outputs.vex-file }}
+      ${{ steps.vens.outputs.attestation-file }}
+```
+
+The attestation is evidence (hashes plus the raw response), not a cryptographic signature, and it spells out the model's reasoning in clear text, so keep it access-controlled rather than in a public artifact. Requires vens-action v0.2.0 or later.
+
 ## Using the mock provider in CI
 
 For testing or cost savings, use the `mock` LLM provider — it returns fixed scores and costs nothing:
 
 ```yaml
-- uses: venslabs/vens-action@v0.1.0
+- uses: venslabs/vens-action@v0.2.0
   with:
     version: v0.3.2
     config-file: .vens/config.yaml
@@ -63,7 +85,7 @@ Good for gating builds on presence of a VEX file without calling external LLM se
 Pre-install the vens binary and pass `bin-path`:
 
 ```yaml
-- uses: venslabs/vens-action@v0.1.0
+- uses: venslabs/vens-action@v0.2.0
   with:
     bin-path: /opt/bin/vens
     config-file: .vens/config.yaml

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -44,25 +44,7 @@ The `llm-api-key` is passed as an environment variable (never a CLI argument) an
 
 ## Attestation
 
-Set `attest: "true"` to also emit a [CycloneDX Attestations (CDXA)](https://cyclonedx.org/capabilities/attestations/) file next to the VEX, recording how each CVE was scored (model, seed, prompt/input/config hashes, raw LLM response) for audit and reproduction. Its path is exposed as the `attestation-file` output:
-
-```yaml
-- name: Prioritize with vens
-  id: vens
-  uses: venslabs/vens-action@v0.2.0
-  with:
-    # ...usual inputs...
-    attest: "true"
-
-- uses: actions/upload-artifact@v4
-  with:
-    name: vens-output
-    path: |
-      ${{ steps.vens.outputs.vex-file }}
-      ${{ steps.vens.outputs.attestation-file }}
-```
-
-The attestation is evidence (hashes plus the raw response), not a cryptographic signature, and it spells out the model's reasoning in clear text, so keep it access-controlled rather than in a public artifact. Requires vens-action v0.2.0 or later.
+Set `attest: "true"` to also emit a [CycloneDX attestation](https://cyclonedx.org/capabilities/attestations/) next to the VEX, recording how each CVE was scored (model, seed, prompt/input/config hashes, raw response) for audit and reproduction. Add the `attestation-file` output to your `upload-artifact` paths to keep it. It is evidence, not a cryptographic signature, and includes the model's reasoning in clear text, so keep it access-controlled. Requires vens-action v0.2.0.
 
 ## Using the mock provider in CI
 

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -30,6 +30,8 @@ vens generate \
 
 **Context**: See `config.yaml` for the risk profile (exposure, data sensitivity, compliance, security controls)
 
+**Audit trail**: add `--attest` to the command to also write `output_vex.attestation.cdx.json`, a [CycloneDX attestation](../../docs/reference/generate.md#--attest) recording how each CVE was scored (model, seed, prompt/input/config hashes, raw response) so a run can be audited and reproduced.
+
 ## How It Works
 
 ```


### PR DESCRIPTION
The docs still pinned vens-action @v0.1.0 and didn't mention the attestation now that the action exposes it. Bumps the examples/SHA-pin to v0.2.0 (README, installation, github-actions) and documents `attest`/`attestation-file` in the CI guide, quickstart, and limitations. Docs only.