### PR TITLE
chore: prep v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OWASP scoring (`Risk = Likelihood × Impact`, 0-81) reflects your system's expos
 ```yaml
 - uses: venslabs/vens-action@v0.2.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
-    version: v0.3.2                   # vens binary version
+    version: v0.4.0                   # vens binary version
     config-file: .vens/config.yaml    # see docs/guides/configuration.md to author this file
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,7 +16,7 @@ If you scan with Trivy or Grype in GitHub Actions, drop [`venslabs/vens-action`]
 - name: Prioritize with vens
   uses: venslabs/vens-action@v0.2.0   # check the marketplace for the latest tag; pin by SHA in production
   with:
-    version: v0.3.2                   # vens binary version
+    version: v0.4.0                   # vens binary version
     config-file: .vens/config.yaml    # see ../guides/configuration.md to author this file
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -14,7 +14,7 @@ Add this to your workflow after a container or dependency scan:
   id: vens
   uses: venslabs/vens-action@v0.2.0
   with:
-    version: v0.3.2
+    version: v0.4.0
     config-file: .vens/config.yaml
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
@@ -53,7 +53,7 @@ For testing or cost savings, use the `mock` LLM provider — it returns fixed sc
 ```yaml
 - uses: venslabs/vens-action@v0.2.0
   with:
-    version: v0.3.2
+    version: v0.4.0
     config-file: .vens/config.yaml
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}

--- a/docs/guides/prioritize-cves.md
+++ b/docs/guides/prioritize-cves.md
@@ -154,7 +154,7 @@ For a turnkey Action, see [GitHub Actions integration](github-actions.md). The m
 
 ```yaml
 - name: Install Vens
-  run: go install github.com/venslabs/vens/cmd/vens@v0.3.2
+  run: go install github.com/venslabs/vens/cmd/vens@v0.4.0
 
 - name: Scan image
   run: trivy image $IMAGE --format json --output report.json

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 # Trivy plugin manifest <https://aquasecurity.github.io/trivy/v0.56/docs/plugin/developer-guide/>
 name: "vens"
-version: "0.3.2"
+version: "0.4.0"
 repository: github.com/venslabs/vens
 maintainer: fahedouch
 summary: Evaluate and prioritize vulnerabilities based on context
@@ -11,20 +11,20 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/venslabs/vens/releases/download/v0.3.2/vens-v0.3.2-darwin-amd64.tar.gz
+    uri: https://github.com/venslabs/vens/releases/download/v0.4.0/vens-v0.4.0-darwin-amd64.tar.gz
     bin: ./vens
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/venslabs/vens/releases/download/v0.3.2/vens-v0.3.2-darwin-arm64.tar.gz
+    uri: https://github.com/venslabs/vens/releases/download/v0.4.0/vens-v0.4.0-darwin-arm64.tar.gz
     bin: ./vens
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/venslabs/vens/releases/download/v0.3.2/vens-v0.3.2-linux-amd64.tar.gz
+    uri: https://github.com/venslabs/vens/releases/download/v0.4.0/vens-v0.4.0-linux-amd64.tar.gz
     bin: ./vens
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/venslabs/vens/releases/download/v0.3.2/vens-v0.3.2-linux-arm64.tar.gz
+    uri: https://github.com/venslabs/vens/releases/download/v0.4.0/vens-v0.4.0-linux-arm64.tar.gz
     bin: ./vens


### PR DESCRIPTION
Version bump ahead of the v0.4.0 tag: `plugin.yaml` (manifest version + the four release download URLs) and the docs version examples, v0.3.2 -> v0.4.0.

Once this merges I'll tag `v0.4.0` to trigger the release build.
