### PR TITLE
ci: build releases with the Go version from go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Install go"
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: "1.25"
+        go-version-file: "go.mod"
         check-latest: true
 
     - name: "Compile binaries"


### PR DESCRIPTION
The v0.4.0 release build failed: `go.mod` requires `go 1.26.3` (raised in #156) but the release job pinned `go-version: "1.25"` with `GOTOOLCHAIN=local`, so it couldn't compile. `main.yml` uses `stable`, which is why CI stayed green and hid it.

Switch the release job to `go-version-file: go.mod` so it always uses the Go version go.mod requires. Once this merges I'll re-tag v0.4.0 to re-run the release.
