### PR TITLE
fix: correct the quickstart in the release-note template

### DIFF
--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -36,8 +36,8 @@ A GitHub build-provenance attestation is also published; see the docs for verifi
 export OPENAI_API_KEY="your-key"
 vens generate \\
   --config-file config.yaml \\
-  --sboms sbom.cdx.json \\
-  trivy.json \\
-  output_vex.json
+  --sbom-serial-number "urn:uuid:..." \\
+  report.json \\
+  output.vex.json
 \`\`\`
 EOX


### PR DESCRIPTION
The auto-generated release notes (`hack/generate-release-note.sh`) showed `vens generate --sboms sbom.cdx.json` in the quickstart. `--sboms` isn't a valid flag and the required `--sbom-serial-number` was missing. Surfaced while cutting v0.4.0. Fixed to the correct invocation.
