### PR TITLE
test: cover the 4 LLM provider adapters

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -28,11 +28,13 @@ import (
 )
 
 // truncatingLLM returns llm.ErrTruncated whenever a batch carries more than
-// maxPerCall vulnerabilities; smaller batches score normally. maxOK records the
-// largest batch that was actually scored, so a test can assert the batch shrank.
+// maxPerCall vulnerabilities; smaller batches score normally. It records how it
+// was called so a test can assert the batch was actually split.
 type truncatingLLM struct {
-	maxPerCall int
-	maxOK      int
+	maxPerCall  int
+	calls       int // successful (non-truncated) scoring calls
+	truncations int
+	maxSeen     int // largest batch it was asked to score, truncated or not
 }
 
 func (m *truncatingLLM) Generate(_ context.Context, req llm.Request) (string, error) {
@@ -42,12 +44,14 @@ func (m *truncatingLLM) Generate(_ context.Context, req llm.Request) (string, er
 	if err := json.Unmarshal([]byte(req.Human), &in); err != nil {
 		return "", err
 	}
+	if len(in) > m.maxSeen {
+		m.maxSeen = len(in)
+	}
 	if len(in) > m.maxPerCall {
+		m.truncations++
 		return "", fmt.Errorf("mock truncated: %w", llm.ErrTruncated)
 	}
-	if len(in) > m.maxOK {
-		m.maxOK = len(in)
-	}
+	m.calls++
 
 	out := llmOutput{Results: make([]llmOutputEntry, 0, len(in))}
 	for _, v := range in {
@@ -64,26 +68,36 @@ func (m *truncatingLLM) Generate(_ context.Context, req llm.Request) (string, er
 	return string(b), err
 }
 
-// An oversized batch that the provider truncates is halved and retried until it
-// fits, and every CVE still gets scored.
+// An oversized batch that the provider truncates is split and retried until it
+// fits; every CVE is scored exactly once (no gaps, no duplicate emission).
 func TestGenerator_AutoSplitsOnTruncation(t *testing.T) {
 	m := &truncatingLLM{maxPerCall: 3}
 	g, err := New(Opts{LLM: m, Config: &riskconfig.Config{}, BatchSize: 10})
 	require.NoError(t, err)
 
-	scored := map[string]bool{}
+	// Collect into a slice (not a set) so a duplicate emission is visible.
+	var emitted []outputhandler.VulnRating
 	h := func(group []outputhandler.VulnRating) error {
-		for _, r := range group {
-			scored[r.VulnID] = true
-		}
+		emitted = append(emitted, group...)
 		return nil
 	}
 
 	require.NoError(t, g.GenerateRiskScore(context.Background(), testVulns(10), h))
 
-	require.Len(t, scored, 10, "every CVE must be scored after splitting")
-	require.LessOrEqual(t, m.maxOK, m.maxPerCall, "successful batches must fit the provider limit")
-	require.Greater(t, m.maxOK, 0)
+	counts := map[string]int{}
+	for _, r := range emitted {
+		counts[r.VulnID]++
+	}
+	require.Len(t, emitted, 10, "expected exactly 10 ratings")
+	require.Len(t, counts, 10, "every CVE must be scored")
+	for id, n := range counts {
+		require.Equalf(t, 1, n, "CVE %s emitted %d times", id, n)
+	}
+
+	// The split path was actually exercised, not a lucky single call.
+	require.Equal(t, 10, m.maxSeen, "the full 10-CVE batch must be attempted first")
+	require.Greater(t, m.truncations, 0, "a truncation must trigger the split")
+	require.Greater(t, m.calls, 1, "the batch must be scored across several sub-batches")
 }
 
 // When even a single CVE truncates, the run surfaces the error instead of

--- a/pkg/llm/providers/anthropic/anthropic_test.go
+++ b/pkg/llm/providers/anthropic/anthropic_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/venslabs/vens/pkg/llm"
+)
+
+// recordedReq captures what the fake Anthropic endpoint received.
+type recordedReq struct {
+	path   string
+	method string
+	body   map[string]any
+	raw    string
+	hits   int
+}
+
+// newTestClient points the SDK at an httptest server via ANTHROPIC_BASE_URL
+// (read natively by anthropic-sdk-go), returning a real adapter Client plus the
+// capture. Uses t.Setenv, so tests must not call t.Parallel.
+func newTestClient(t *testing.T, model string, status int, respBody string) (*Client, *recordedReq) {
+	t.Helper()
+	rec := &recordedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.hits++
+		rec.path = r.URL.Path
+		rec.method = r.Method
+		b, _ := io.ReadAll(r.Body)
+		rec.raw = string(b)
+		_ = json.Unmarshal(b, &rec.body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+
+	c, err := New(model)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c, rec
+}
+
+const successBody = `{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5",` +
+	`"content":[{"type":"text","text":"{\"cves\":[]}"}],"stop_reason":"end_turn","stop_sequence":null,` +
+	`"usage":{"input_tokens":1,"output_tokens":1}}`
+
+func newReq() llm.Request {
+	return llm.Request{
+		System:      "you are vens",
+		Human:       "score these cves",
+		Schema:      json.RawMessage(`{"type":"object","properties":{"cves":{"type":"array"}}}`),
+		Temperature: 0,
+		Seed:        42, // Anthropic has no seed param; must be ignored
+	}
+}
+
+// The outgoing request carries the schema in output_config.format, a hardcoded
+// max_tokens, an explicit temperature=0, the system block, and no seed.
+func TestGenerate_OutgoingRequest(t *testing.T) {
+	c, rec := newTestClient(t, "claude-sonnet-4-5", 200, successBody)
+
+	out, err := c.Generate(context.Background(), newReq())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if out != `{"cves":[]}` {
+		t.Fatalf("out = %q", out)
+	}
+
+	if rec.method != http.MethodPost || rec.path != "/v1/messages" {
+		t.Fatalf("hit %s %s", rec.method, rec.path)
+	}
+	if rec.body["model"] != "claude-sonnet-4-5" {
+		t.Errorf("model = %v", rec.body["model"])
+	}
+	if rec.body["max_tokens"] != float64(16384) {
+		t.Errorf("max_tokens = %v", rec.body["max_tokens"])
+	}
+	if !strings.Contains(rec.raw, `"temperature":0`) {
+		t.Errorf("temperature not sent as 0: %s", rec.raw)
+	}
+	if _, ok := rec.body["seed"]; ok {
+		t.Error("seed must not be sent")
+	}
+
+	sys := rec.body["system"].([]any)
+	sb := sys[0].(map[string]any)
+	if sb["type"] != "text" || sb["text"] != "you are vens" {
+		t.Errorf("system block = %v", sb)
+	}
+
+	msgs := rec.body["messages"].([]any)
+	m0 := msgs[0].(map[string]any)
+	content := m0["content"].([]any)
+	cb := content[0].(map[string]any)
+	if m0["role"] != "user" || cb["type"] != "text" || cb["text"] != "score these cves" {
+		t.Errorf("user msg = %v", m0)
+	}
+
+	oc := rec.body["output_config"].(map[string]any)
+	format := oc["format"].(map[string]any)
+	if format["type"] != "json_schema" {
+		t.Errorf("format.type = %v", format["type"])
+	}
+	var wantSchema map[string]any
+	_ = json.Unmarshal(newReq().Schema, &wantSchema)
+	gotSchema, _ := json.Marshal(format["schema"])
+	wantJSON, _ := json.Marshal(wantSchema)
+	if string(gotSchema) != string(wantJSON) {
+		t.Errorf("schema = %s want %s", gotSchema, wantJSON)
+	}
+}
+
+func TestGenerate_ResponseBranches(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr string // substring; "" => no error
+		errIs   error  // errors.Is target; nil => skip
+	}{
+		{
+			name:   "success",
+			status: 200, body: successBody,
+			want: `{"cves":[]}`,
+		},
+		{
+			name:    "truncated_max_tokens",
+			status:  200,
+			body:    `{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"text","text":"partial"}],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`,
+			wantErr: "max_tokens", errIs: llm.ErrTruncated,
+		},
+		{
+			name:    "no_text_block",
+			status:  200,
+			body:    `{"id":"m","type":"message","role":"assistant","model":"x","content":[{"type":"tool_use","id":"t","name":"n","input":{}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`,
+			wantErr: "no text content block",
+		},
+		{
+			name:    "api_error_400",
+			status:  400,
+			body:    `{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`,
+			wantErr: "message failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := newTestClient(t, "x", tt.status, tt.body)
+			got, err := c.Generate(context.Background(), newReq())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("got %q want %q", got, tt.want)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want contains %q", err, tt.wantErr)
+			}
+			if tt.errIs != nil && !errors.Is(err, tt.errIs) {
+				t.Fatalf("err = %v, want errors.Is %v", err, tt.errIs)
+			}
+		})
+	}
+}
+
+// An invalid schema fails before any network call.
+func TestGenerate_InvalidSchema_NoNetwork(t *testing.T) {
+	c, rec := newTestClient(t, "x", 200, successBody)
+	req := newReq()
+	req.Schema = json.RawMessage(`not-json`)
+	_, err := c.Generate(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "invalid schema") {
+		t.Fatalf("err = %v", err)
+	}
+	if rec.hits != 0 {
+		t.Errorf("handler should not be hit, got %d", rec.hits)
+	}
+}

--- a/pkg/llm/providers/google/google_test.go
+++ b/pkg/llm/providers/google/google_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/venslabs/vens/pkg/llm"
+)
+
+const testModel = "gemini-2.5-flash"
+
+type recordedReq struct {
+	path   string
+	apiKey string
+	body   map[string]any
+}
+
+func newTestServer(t *testing.T, status int, respBody string, rec *recordedReq) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rec != nil {
+			rec.path = r.URL.Path
+			rec.apiKey = r.Header.Get("x-goog-api-key")
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &rec.body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestClient points the genai SDK at the fake server via GOOGLE_GEMINI_BASE_URL.
+// t.Setenv forbids t.Parallel in these tests.
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	t.Setenv("GOOGLE_API_KEY", "test-key")
+	t.Setenv("GOOGLE_GEMINI_BASE_URL", baseURL)
+	c, err := New(context.Background(), testModel)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func firstPartText(content map[string]any) string {
+	if content == nil {
+		return ""
+	}
+	parts, _ := content["parts"].([]any)
+	if len(parts) == 0 {
+		return ""
+	}
+	p, _ := parts[0].(map[string]any)
+	s, _ := p["text"].(string)
+	return s
+}
+
+// The outgoing request carries the schema in responseJsonSchema, the system
+// instruction, an explicit temperature=0 and a non-zero seed.
+func TestGenerate_RequestShape(t *testing.T) {
+	var rec recordedReq
+	success := `{"candidates":[{"content":{"parts":[{"text":"{\"ok\":true}"}],"role":"model"},"finishReason":"STOP"}]}`
+	srv := newTestServer(t, http.StatusOK, success, &rec)
+	c := newTestClient(t, srv.URL)
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"additionalProperties":false}`)
+	req := llm.Request{System: "you are a scanner", Human: "score CVE-2021-1234", Schema: schema, Temperature: 0, Seed: 42}
+
+	got, err := c.Generate(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("got %q", got)
+	}
+
+	if !strings.HasSuffix(rec.path, ":generateContent") || !strings.Contains(rec.path, "models/"+testModel) {
+		t.Fatalf("unexpected path %q", rec.path)
+	}
+	if rec.apiKey != "test-key" {
+		t.Fatalf("x-goog-api-key = %q", rec.apiKey)
+	}
+
+	gen, _ := rec.body["generationConfig"].(map[string]any)
+	if gen == nil {
+		t.Fatal("missing generationConfig")
+	}
+	if gen["responseMimeType"] != "application/json" {
+		t.Fatalf("responseMimeType = %v", gen["responseMimeType"])
+	}
+	var wantSchema any
+	_ = json.Unmarshal(schema, &wantSchema)
+	if !reflect.DeepEqual(gen["responseJsonSchema"], wantSchema) {
+		t.Fatalf("responseJsonSchema = %#v", gen["responseJsonSchema"])
+	}
+	if gen["temperature"] != float64(0) {
+		t.Fatalf("temperature = %v", gen["temperature"])
+	}
+	if gen["seed"] != float64(42) {
+		t.Fatalf("seed = %v", gen["seed"])
+	}
+
+	sys, _ := rec.body["systemInstruction"].(map[string]any)
+	if txt := firstPartText(sys); txt != "you are a scanner" {
+		t.Fatalf("systemInstruction text = %q", txt)
+	}
+	contents, _ := rec.body["contents"].([]any)
+	if len(contents) == 0 {
+		t.Fatal("missing contents")
+	}
+	first, _ := contents[0].(map[string]any)
+	if first["role"] != "user" {
+		t.Fatalf("role = %v", first["role"])
+	}
+	if txt := firstPartText(first); txt != "score CVE-2021-1234" {
+		t.Fatalf("human text = %q", txt)
+	}
+}
+
+func TestGenerate_SeedOmittedWhenZero(t *testing.T) {
+	var rec recordedReq
+	srv := newTestServer(t, http.StatusOK, `{"candidates":[{"content":{"parts":[{"text":"{}"}]},"finishReason":"STOP"}]}`, &rec)
+	c := newTestClient(t, srv.URL)
+	if _, err := c.Generate(context.Background(), llm.Request{Human: "hi", Seed: 0}); err != nil {
+		t.Fatal(err)
+	}
+	gen, _ := rec.body["generationConfig"].(map[string]any)
+	if _, ok := gen["seed"]; ok {
+		t.Fatal("seed must be omitted when req.Seed == 0")
+	}
+	if _, ok := gen["temperature"]; !ok {
+		t.Fatal("temperature must be present even at 0")
+	}
+}
+
+func TestGenerate_Branches(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		want      string
+		wantErr   string
+		wantTrunc bool
+	}{
+		{name: "success", status: 200, body: `{"candidates":[{"content":{"parts":[{"text":"{\"a\":1}"}]},"finishReason":"STOP"}]}`, want: `{"a":1}`},
+		{name: "truncated", status: 200, body: `{"candidates":[{"finishReason":"MAX_TOKENS","content":{"parts":[{"text":"{\"a\":"}]}}]}`, wantTrunc: true},
+		{name: "no candidates", status: 200, body: `{}`, wantErr: "no candidates"},
+		{name: "prompt blocked", status: 200, body: `{"promptFeedback":{"blockReason":"SAFETY"}}`, wantErr: "prompt_blocked=SAFETY"},
+		{name: "candidate safety empty", status: 200, body: `{"candidates":[{"finishReason":"SAFETY"}]}`, wantErr: "finish_reason=SAFETY"},
+		{name: "api error", status: 500, body: `{"error":{"code":500,"message":"boom","status":"INTERNAL"}}`, wantErr: "generate content"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(t, tt.status, tt.body, nil)
+			c := newTestClient(t, srv.URL)
+			got, err := c.Generate(context.Background(), llm.Request{Human: "x", Schema: json.RawMessage(`{"type":"object"}`)})
+			switch {
+			case tt.wantTrunc:
+				if !errors.Is(err, llm.ErrTruncated) {
+					t.Fatalf("want ErrTruncated, got %v", err)
+				}
+			case tt.wantErr != "":
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+			default:
+				if err != nil || got != tt.want {
+					t.Fatalf("got (%q,%v) want %q", got, err, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/llm/providers/ollama/ollama_test.go
+++ b/pkg/llm/providers/ollama/ollama_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025 venslabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	oapi "github.com/ollama/ollama/api"
+
+	"github.com/venslabs/vens/pkg/llm"
+)
+
+// newFakeServer registers a POST /api/chat handler that records the decoded
+// request and replies with the given NDJSON body (one or more JSON lines).
+func newFakeServer(t *testing.T, status int, body string, captured *oapi.ChatRequest) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/chat", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, captured); err != nil {
+			t.Fatalf("decode request: %v (body=%s)", err, raw)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func jsonEqual(a, b []byte) bool {
+	var x, y any
+	if json.Unmarshal(a, &x) != nil || json.Unmarshal(b, &y) != nil {
+		return false
+	}
+	ab, _ := json.Marshal(x)
+	bb, _ := json.Marshal(y)
+	return string(ab) == string(bb)
+}
+
+// The outgoing request carries the schema as Format, Stream=false, the
+// system/user split, and Options with temperature=0 and a non-zero seed.
+func TestGenerate_RequestShapeAndSuccess(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"score":{"type":"integer"}}}`)
+	var got oapi.ChatRequest
+	srv := newFakeServer(t, 200,
+		`{"model":"m","message":{"role":"assistant","content":"{\"score\":7}"},"done":true,"done_reason":"stop"}`,
+		&got)
+
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	c, err := New("m")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := c.Generate(context.Background(), llm.Request{
+		System:      "sys",
+		Human:       "hum",
+		Schema:      schema,
+		Temperature: 0,
+		Seed:        42,
+	})
+	if err != nil {
+		t.Fatalf("Generate err = %v", err)
+	}
+	if out != `{"score":7}` {
+		t.Errorf("out = %q", out)
+	}
+
+	if got.Model != "m" {
+		t.Errorf("model = %q", got.Model)
+	}
+	if len(got.Messages) != 2 ||
+		got.Messages[0].Role != "system" || got.Messages[0].Content != "sys" ||
+		got.Messages[1].Role != "user" || got.Messages[1].Content != "hum" {
+		t.Errorf("messages = %+v", got.Messages)
+	}
+	if got.Stream == nil || *got.Stream != false {
+		t.Errorf("stream = %v, want *false", got.Stream)
+	}
+	if !jsonEqual(got.Format, schema) {
+		t.Errorf("format = %s, want %s", got.Format, schema)
+	}
+	if v, ok := got.Options["temperature"].(float64); !ok || v != 0 {
+		t.Errorf("temperature = %v (%T)", got.Options["temperature"], got.Options["temperature"])
+	}
+	if v, ok := got.Options["seed"].(float64); !ok || v != 42 {
+		t.Errorf("seed = %v, want 42", got.Options["seed"])
+	}
+}
+
+func TestGenerate_SeedOmittedWhenZero(t *testing.T) {
+	var got oapi.ChatRequest
+	srv := newFakeServer(t, 200,
+		`{"model":"m","message":{"content":"{}"},"done":true,"done_reason":"stop"}`, &got)
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	c, _ := New("m")
+	if _, err := c.Generate(context.Background(), llm.Request{Human: "h", Seed: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Options["seed"]; ok {
+		t.Errorf("seed present but Seed==0: %v", got.Options["seed"])
+	}
+}
+
+func TestGenerate_Branches(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		wantOut   string
+		wantErr   bool
+		wantTrunc bool
+		errSub    string
+	}{
+		{
+			name:      "truncation_length",
+			status:    200,
+			body:      `{"message":{"content":"{\"score\":"},"done":true,"done_reason":"length"}`,
+			wantErr:   true,
+			wantTrunc: true,
+		},
+		{
+			name:    "empty_response",
+			status:  200,
+			body:    `{"message":{"content":""},"done":true,"done_reason":"stop"}`,
+			wantErr: true,
+			errSub:  "empty response",
+		},
+		{
+			name:    "multi_chunk_concat",
+			status:  200,
+			body:    "{\"message\":{\"content\":\"{\\\"score\\\":\"},\"done\":false}\n{\"message\":{\"content\":\"7}\"},\"done\":true,\"done_reason\":\"stop\"}",
+			wantOut: `{"score":7}`,
+		},
+		{
+			name:    "http_500",
+			status:  500,
+			body:    `{"error":"model not found"}`,
+			wantErr: true,
+			errSub:  "chat",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got oapi.ChatRequest
+			srv := newFakeServer(t, tt.status, tt.body, &got)
+			t.Setenv("OLLAMA_HOST", srv.URL)
+			c, _ := New("m")
+			out, err := c.Generate(context.Background(), llm.Request{Human: "h"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				if tt.wantTrunc && !errors.Is(err, llm.ErrTruncated) {
+					t.Errorf("want ErrTruncated, got %v", err)
+				}
+				if tt.errSub != "" && !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("err %q missing %q", err, tt.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if out != tt.wantOut {
+				t.Errorf("out = %q, want %q", out, tt.wantOut)
+			}
+		})
+	}
+}

--- a/pkg/llm/providers/openai/openai_test.go
+++ b/pkg/llm/providers/openai/openai_test.go
@@ -14,7 +14,19 @@
 
 package openai
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/venslabs/vens/pkg/llm"
+)
 
 func TestIsReasoningModel(t *testing.T) {
 	cases := map[string]bool{
@@ -38,5 +50,194 @@ func TestIsReasoningModel(t *testing.T) {
 		if got := isReasoningModel(model); got != want {
 			t.Errorf("isReasoningModel(%q) = %v, want %v", model, got, want)
 		}
+	}
+}
+
+const testSchema = `{"type":"object","properties":{"score":{"type":"number"}},"required":["score"],"additionalProperties":false}`
+
+const successBody = `{"id":"cmpl-1","object":"chat.completion","created":0,"model":"gpt-4o",` +
+	`"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"{\"score\":7}"}}]}`
+
+// fakeServer serves one canned reply and captures the decoded request body,
+// which is populated by the time Generate returns.
+func fakeServer(t *testing.T, status int, respBody string) (url string, captured *map[string]any) {
+	t.Helper()
+	body := map[string]any{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %s, want /chat/completions", r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("request body not JSON: %v (%s)", err, raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &body
+}
+
+func newTestClient(t *testing.T, model, baseURL string) *Client {
+	t.Helper()
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", baseURL)
+	c, err := New(model)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// A gpt-4o request carries the strict json_schema, the system/user split, and an
+// explicit temperature=0 (the deterministic default) plus a non-zero seed.
+func TestGenerate_RequestShape(t *testing.T) {
+	url, captured := fakeServer(t, http.StatusOK, successBody)
+	c := newTestClient(t, "gpt-4o", url)
+
+	if _, err := c.Generate(context.Background(), llm.Request{
+		System:      "you are a scorer",
+		Human:       "score this",
+		Schema:      json.RawMessage(testSchema),
+		Temperature: 0,
+		Seed:        42,
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	req := *captured
+
+	if req["model"] != "gpt-4o" {
+		t.Errorf("model = %v", req["model"])
+	}
+
+	msgs, _ := req["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("messages len = %d", len(msgs))
+	}
+	sys := msgs[0].(map[string]any)
+	usr := msgs[1].(map[string]any)
+	if sys["role"] != "system" || sys["content"] != "you are a scorer" {
+		t.Errorf("system msg = %v", sys)
+	}
+	if usr["role"] != "user" || usr["content"] != "score this" {
+		t.Errorf("user msg = %v", usr)
+	}
+
+	rf := req["response_format"].(map[string]any)
+	if rf["type"] != "json_schema" {
+		t.Errorf("response_format.type = %v", rf["type"])
+	}
+	js := rf["json_schema"].(map[string]any)
+	if js["name"] != "vens_response" {
+		t.Errorf("json_schema.name = %v", js["name"])
+	}
+	if js["strict"] != true {
+		t.Errorf("json_schema.strict = %v", js["strict"])
+	}
+	var wantSchema map[string]any
+	_ = json.Unmarshal([]byte(testSchema), &wantSchema)
+	if !reflect.DeepEqual(js["schema"], wantSchema) {
+		t.Errorf("schema mismatch:\n got %v\nwant %v", js["schema"], wantSchema)
+	}
+
+	// temperature 0 is sent explicitly for non-reasoning models (determinism).
+	if temp, ok := req["temperature"]; !ok || temp.(float64) != 0 {
+		t.Errorf("temperature = %v (present=%v), want 0", req["temperature"], ok)
+	}
+	if s, ok := req["seed"]; !ok || s.(float64) != 42 {
+		t.Errorf("seed = %v (present=%v), want 42", req["seed"], ok)
+	}
+}
+
+// Reasoning models must not receive an explicit temperature, and seed is omitted
+// when zero.
+func TestGenerate_OmitsTemperatureAndSeed(t *testing.T) {
+	t.Run("reasoning model omits temperature", func(t *testing.T) {
+		url, captured := fakeServer(t, http.StatusOK, successBody)
+		c := newTestClient(t, "o3-mini", url)
+		if _, err := c.Generate(context.Background(), llm.Request{
+			Schema:      json.RawMessage(testSchema),
+			Temperature: 0.7,
+		}); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if _, ok := (*captured)["temperature"]; ok {
+			t.Error("reasoning model must omit temperature")
+		}
+	})
+
+	t.Run("zero seed omitted", func(t *testing.T) {
+		url, captured := fakeServer(t, http.StatusOK, successBody)
+		c := newTestClient(t, "gpt-4o", url)
+		if _, err := c.Generate(context.Background(), llm.Request{Schema: json.RawMessage(testSchema)}); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if _, ok := (*captured)["seed"]; ok {
+			t.Error("seed must be omitted when 0")
+		}
+	})
+}
+
+func TestGenerate_Branches(t *testing.T) {
+	cases := []struct {
+		name          string
+		body          string
+		wantOut       string
+		wantErrSubstr string
+		wantTruncated bool
+	}{
+		{name: "success", body: successBody, wantOut: `{"score":7}`},
+		{
+			name:          "truncation",
+			body:          `{"choices":[{"index":0,"finish_reason":"length","message":{"role":"assistant","content":"{\"score\":7"}}]}`,
+			wantErrSubstr: "finish_reason=length",
+			wantTruncated: true,
+		},
+		{
+			name:          "refusal",
+			body:          `{"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","refusal":"I cannot help with that","content":""}}]}`,
+			wantErrSubstr: "model refused: I cannot help with that",
+		},
+		{
+			name:          "empty content",
+			body:          `{"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":""}}]}`,
+			wantErrSubstr: "empty content (finish_reason=stop)",
+		},
+		{
+			name:          "no choices",
+			body:          `{"id":"cmpl-1","object":"chat.completion","choices":[]}`,
+			wantErrSubstr: "no choices returned",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url, _ := fakeServer(t, http.StatusOK, tc.body)
+			c := newTestClient(t, "gpt-4o", url)
+			out, err := c.Generate(context.Background(), llm.Request{
+				System: "s", Human: "h", Schema: json.RawMessage(testSchema),
+			})
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if out != tc.wantOut {
+					t.Errorf("out = %q, want %q", out, tc.wantOut)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Errorf("err = %q, want substring %q", err.Error(), tc.wantErrSubstr)
+			}
+			if got := errors.Is(err, llm.ErrTruncated); got != tc.wantTruncated {
+				t.Errorf("errors.Is(ErrTruncated) = %v, want %v", got, tc.wantTruncated)
+			}
+		})
 	}
 }


### PR DESCRIPTION
httptest-based unit tests for the openai/anthropic/google/ollama adapters — request shape (schema, system/human split, temperature, seed) + every response/error branch including truncation. Also a real no-duplicate-emission check on the batch auto-split.