### PR TITLE
docs: refresh model examples to the current defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OWASP scoring (`Risk = Likelihood × Impact`, 0-81) reflects your system's expos
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: openai
-    llm-model: gpt-4o
+    llm-model: gpt-5.4-mini
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
     fail-on-severity: critical        # break the build on critical OWASP risk
 ```
@@ -59,7 +59,7 @@ trivy plugin install github.com/venslabs/vens
 ```bash
 # 1. Set up LLM (OpenAI shown — Anthropic, Google AI, or local Ollama also supported)
 export OPENAI_API_KEY="sk-..."
-export OPENAI_MODEL="gpt-4o"
+export OPENAI_MODEL="gpt-5.4-mini"
 
 # 2. Scan with Trivy or Grype
 trivy image python:3.11-slim --format json --output report.json

--- a/cmd/vens/commands/enrich/enrich.go
+++ b/cmd/vens/commands/enrich/enrich.go
@@ -51,7 +51,7 @@ func Example() string {
 	}
 	return fmt.Sprintf(`  # Basic usage
   export OPENAI_API_KEY=...
-  export OPENAI_MODEL=gpt-4o
+  export OPENAI_MODEL=gpt-5.4-mini
 
   trivy image nginx:1.25 --format=json --severity HIGH,CRITICAL > report.json
 

--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -80,7 +80,7 @@ func Example() string {
 	}
 	return fmt.Sprintf(`  # Basic usage
   export OPENAI_API_KEY=...
-  export OPENAI_MODEL=gpt-4o
+  export OPENAI_MODEL=gpt-5.4-mini
 
   # Scan an image and generate a vulnerability report
   trivy image nginx:1.25 --format=json --severity HIGH,CRITICAL > report.json

--- a/docs/TRIVY_PLUGIN.md
+++ b/docs/TRIVY_PLUGIN.md
@@ -13,7 +13,7 @@ trivy plugin install github.com/venslabs/vens
 ```bash
 # 1. Set up LLM
 export OPENAI_API_KEY="sk-..."
-export OPENAI_MODEL="gpt-4o"
+export OPENAI_MODEL="gpt-5.4-mini"
 
 # 2. Scan with Trivy
 trivy image nginx:1.25 --format json --severity HIGH,CRITICAL > report.json
@@ -75,8 +75,8 @@ context:
 
 | Provider | Environment Variable | Example |
 |----------|---------------------|---------|
-| OpenAI (recommended) | `OPENAI_API_KEY` | `export OPENAI_MODEL="gpt-4o"` |
-| Anthropic | `ANTHROPIC_API_KEY` | `export ANTHROPIC_MODEL="claude-sonnet-4-5"` |
+| OpenAI (recommended) | `OPENAI_API_KEY` | `export OPENAI_MODEL="gpt-5.4-mini"` |
+| Anthropic | `ANTHROPIC_API_KEY` | `export ANTHROPIC_MODEL="claude-sonnet-4-6"` |
 | Ollama (local) | `OLLAMA_MODEL` | `export OLLAMA_MODEL="llama3"` |
 | Google AI | `GOOGLE_API_KEY` | `export GOOGLE_MODEL="gemini-2.5-flash"` |
 

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -73,7 +73,7 @@ Vens itself is an MIT-ish Apache 2.0 Go binary — it holds no data and signs no
 
 ## 7. Score quality drops on models below ~7B parameters
 
-Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under 7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. `llama3.1:70b` and larger cloud models (gpt-4o, claude-sonnet-4-5, gemini-2.5-flash) are the sweet spot; lighter models are usable with `--llm-batch-size 3–5` but with lower quality.
+Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under 7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. `llama3.1:70b` and larger cloud models (gpt-5.4-mini, claude-sonnet-4-6, gemini-2.5-flash) are the sweet spot; lighter models are usable with `--llm-batch-size 3–5` but with lower quality.
 
 This is a fundamental constraint of today's open-weight model landscape — if you need air-gapped + high quality, plan for a beefy GPU box.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ If you scan with Trivy or Grype in GitHub Actions, drop [`venslabs/vens-action`]
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: openai
-    llm-model: gpt-4o
+    llm-model: gpt-5.4-mini
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
     fail-on-severity: critical        # break the build on critical OWASP risk
 ```
@@ -174,7 +174,7 @@ Vens asks the LLM to return structured JSON with four 0–9 component scores per
 
     ```bash
     export OPENAI_API_KEY="sk-..."
-    export OPENAI_MODEL="gpt-4o"
+    export OPENAI_MODEL="gpt-5.4-mini"
     ```
 
     Among the cloud providers, OpenAI and Google AI accept the `seed` parameter Vens forwards (`--llm-seed`); Anthropic has no seed parameter and silently ignores it. This does not guarantee byte-identical scores across runs — see [Reference: `--llm-seed`](../reference/generate.md#--llm-seed-int) and [Limitations](../concepts/limitations.md).
@@ -183,7 +183,7 @@ Vens asks the LLM to return structured JSON with four 0–9 component scores per
 
     ```bash
     export ANTHROPIC_API_KEY="sk-ant-..."
-    export ANTHROPIC_MODEL="claude-sonnet-4-5"
+    export ANTHROPIC_MODEL="claude-sonnet-4-6"
     ```
 
 === "Google AI"

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -19,7 +19,7 @@ Add this to your workflow after a container or dependency scan:
     input-report: report.json
     sbom-serial-number: ${{ vars.SBOM_SERIAL }}
     llm-provider: openai
-    llm-model: gpt-4o
+    llm-model: gpt-5.4-mini
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
     fail-on-severity: critical
     enrich: "true"

--- a/docs/guides/prioritize-cves.md
+++ b/docs/guides/prioritize-cves.md
@@ -88,7 +88,7 @@ vens generate \
 
 `--sbom-serial-number` is required — pass the `serialNumber` of the CycloneDX SBOM paired with this scan so each `affects` in the VEX resolves back to that SBOM via BOM-Link.
 
-Runtime: ~1 minute for 300 CVEs with `gpt-4o`.
+Runtime: ~1 minute for 300 CVEs with `gpt-5.4-mini`.
 
 ---
 
@@ -162,7 +162,7 @@ For a turnkey Action, see [GitHub Actions integration](github-actions.md). The m
 - name: Generate contextual VEX
   env:
     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    OPENAI_MODEL: gpt-4o               # required alongside OPENAI_API_KEY
+    OPENAI_MODEL: gpt-5.4-mini               # required alongside OPENAI_API_KEY
     # Stable per-service UUID so BOM-Links don't churn between builds.
     # Store it as a repo variable instead of hardcoding once you have more than one service.
     SBOM_UUID: urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79

--- a/docs/reference/generate.md
+++ b/docs/reference/generate.md
@@ -182,7 +182,7 @@ vens generate --attest \
 - `targets.components[]` — the affected components the claims point at
 - `evidence[]` — one per LLM batch, recording how the scoring was produced:
     - `generation_method` — `llm`
-    - `provider` / `model` — backend and model used (e.g. `openai` / `gpt-4o`); when the provider's `*_MODEL` env var is unset, vens falls back to that provider's default and logs it
+    - `provider` / `model` — backend and model used (e.g. `openai` / `gpt-5.4-mini`); when the provider's `*_MODEL` env var is unset, vens falls back to that provider's default and logs it
     - `seed` — the LLM seed (`0` if unset)
     - `temperature` — the sampling temperature
     - `prompt_hash` — SHA-256 of `system_prompt + "\n\n" + human_prompt`
@@ -210,9 +210,9 @@ BOM-Link `version` number used alongside `--sbom-serial-number`. Default: `1`.
 | Variable | Purpose |
 |---|---|
 | `OPENAI_API_KEY` | OpenAI credentials |
-| `OPENAI_MODEL` | OpenAI model name (e.g. `gpt-4o`) |
+| `OPENAI_MODEL` | OpenAI model name (e.g. `gpt-5.4-mini`) |
 | `ANTHROPIC_API_KEY` | Anthropic credentials |
-| `ANTHROPIC_MODEL` | Anthropic model name (e.g. `claude-sonnet-4-5`) |
+| `ANTHROPIC_MODEL` | Anthropic model name (e.g. `claude-sonnet-4-6`) |
 | `GOOGLE_API_KEY` | Google AI credentials |
 | `GEMINI_API_KEY` | Google AI credentials (fallback used when `GOOGLE_API_KEY` is unset) |
 | `GOOGLE_MODEL` | Google AI model name (e.g. `gemini-2.5-flash`) |
@@ -245,7 +245,7 @@ SBOM_UUID="urn:uuid:$(uuidgen | tr '[:upper:]' '[:lower:]')"
 
 ```bash
 export OPENAI_API_KEY=sk-...
-export OPENAI_MODEL=gpt-4o
+export OPENAI_MODEL=gpt-5.4-mini
 
 trivy image python:3.11-slim --format json --output report.json
 vens generate --config-file vens.yaml --sbom-serial-number "$SBOM_UUID" report.json vex.json
@@ -273,7 +273,7 @@ vens generate \
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-export ANTHROPIC_MODEL=claude-sonnet-4-5
+export ANTHROPIC_MODEL=claude-sonnet-4-6
 vens generate --llm anthropic --config-file vens.yaml --sbom-serial-number "$SBOM_UUID" report.json vex.json
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,8 +54,8 @@ Your `config.yaml` has a typo, an extra word, or a missing required field. Check
 No LLM provider environment variable is set. Export one of:
 
 ```bash
-export OPENAI_API_KEY=sk-...    OPENAI_MODEL=gpt-4o
-export ANTHROPIC_API_KEY=...    ANTHROPIC_MODEL=claude-sonnet-4-5
+export OPENAI_API_KEY=sk-...    OPENAI_MODEL=gpt-5.4-mini
+export ANTHROPIC_API_KEY=...    ANTHROPIC_MODEL=claude-sonnet-4-6
 export GOOGLE_API_KEY=...       GOOGLE_MODEL=gemini-2.5-flash
 export OLLAMA_MODEL=llama3.1    # with a local Ollama running
 ```

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -11,7 +11,7 @@ This example demonstrates how **vens** transforms generic CVSS scores into conte
 
 ```bash
 export OPENAI_API_KEY="sk-..."
-export OPENAI_MODEL="gpt-4o"
+export OPENAI_MODEL="gpt-5.4-mini"
 
 # Using Trivy report (auto-detected)
 vens generate \


### PR DESCRIPTION
Follow-up to the default bump (#197): the docs and CLI `--help` still showed `gpt-4o` / `claude-sonnet-4-5` in their examples. Swept both to `gpt-5.4-mini` / `claude-sonnet-4-6` across 11 files (README, the two `--help` strings, and the docs). Left the Google examples on `gemini-2.5-flash`.