### PR TITLE
docs: rewrite the benchmark blog post (review feedback)

### DIFF
--- a/docs/assets/which-llm-cover.svg
+++ b/docs/assets/which-llm-cover.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Which LLM should score your CVEs? A benchmark of 12 models." font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b2a33"/>
+      <stop offset="1" stop-color="#0f3b49"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <g fill="#3f8ba3" opacity="0.13">
+    <rect x="815" y="150" width="305" height="24" rx="4"/>
+    <rect x="815" y="196" width="255" height="24" rx="4"/>
+    <rect x="815" y="242" width="205" height="24" rx="4"/>
+    <rect x="815" y="288" width="130" height="24" rx="4"/>
+    <rect x="815" y="334" width="78"  height="24" rx="4"/>
+  </g>
+
+  <text x="90" y="146" fill="#7fc4d6" font-size="25" font-weight="600" letter-spacing="4">VENS · BENCHMARK</text>
+  <rect x="90" y="164" width="62" height="4" fill="#7fc4d6"/>
+
+  <text x="86" y="296" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">Which LLM should</text>
+  <text x="86" y="380" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">score your CVEs?</text>
+
+  <text x="90" y="462" fill="#cfe1e7" font-size="32">12 models, measured. Which to run,</text>
+  <text x="90" y="504" fill="#cfe1e7" font-size="32">and where they quietly fail.</text>
+</svg>

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,3 +1,1 @@
 # Blog
-
-Benchmarks and findings from building vens.

--- a/docs/blog/posts/which-llm-should-score-your-cves.md
+++ b/docs/blog/posts/which-llm-should-score-your-cves.md
@@ -1,16 +1,27 @@
 ---
 date: 2026-07-13
+categories:
+  - Benchmark
 slug: which-llm-should-score-your-cves
 ---
 
 # Which LLM should score your CVEs?
 
+![Which LLM should score your CVEs? A benchmark of 12 models.](../../assets/which-llm-cover.svg)
+
 Your scanner finds 400 CVEs. Most don't matter for your system, but the CVSS score can't tell you which: it rates the bug, not your setup.
 
-EPSS and the CISA KEV list help (how likely a CVE is to be exploited, and whether it's exploited today). But they don't know your deployment: internet-facing or internal, holds user data or not, vulnerable code reachable or never run. That last part is the job people now give an LLM: read the scan plus a short context file, and adjust the score. [vens](https://github.com/venslabs/vens) does this. So which model do you run behind it? I tested 12.
+<!-- more -->
 
-**1. Reading a CVE is cheap.**
-First test: read a CVE, predict its CVSS score (I reused the public CTIBench set). Lower error is better.
+EPSS and the CISA KEV list help (how likely a CVE is to be exploited, and whether it is exploited right now). But they don't know your deployment. Is the service internet-facing? Does it hold user data? Is the vulnerable code even reachable? Answering that for *your* system is the job people now give an LLM: it reads the scanner report plus a short context file that you write (a [`config.yaml`](https://github.com/venslabs/vens/blob/main/examples/quickstart/config.yaml) that describes your project), then adjusts the score. [vens](https://github.com/venslabs/vens) does this.
+
+So which model do you put behind it? I tested 12.
+
+vens's scoring comes down to two skills: **read the CVE**, then **use your context**. So I benchmarked both, each against a simple no-LLM rule it has to beat.
+
+## 1. Reading a CVE is cheap
+
+The first skill: read a CVE and predict its CVSS score. I reused the public [CTIBench](https://github.com/xashru/cti-bench) set for this. Lower error is better.
 
 | Model | Error | $ per 200 CVEs |
 |---|---|---|
@@ -20,26 +31,37 @@ First test: read a CVE, predict its CVSS score (I reused the public CTIBench set
 | gemini-2.5-flash-lite | 1.15 | $0.07 |
 | *constant guess* | 1.57 | $0 |
 
-The two best tie. gpt-5.5 costs more than 2× the price for the same result, so skip it. A $0.48 model is almost as good. Don't overpay here. (One catch: these CVEs are likely in the models' training data, so this test is more about memory than reading. Good enough, not solved.)
+The two best models tie. gpt-5.5 costs more than 2x the price for the same result, so skip it. A $0.48 model is almost as good. Don't overpay here.
 
-**2. Context is where cheap models fail.**
-Second test: change the context and check if the score moves the right way. A Log4Shell 10.0 that nothing can reach should drop to LOW, and 7 of 8 models do it. A token leak (6.5) on a public site full of user data should rise to HIGH, and all 8 do.
+One catch: these CVEs are public, so the models have probably seen their scores during training. This test measures memory as much as reading. Good enough, not solved.
 
-Those two are real CVEs, on purpose; the other context tests use made-up ones, so no model can lean on a score it already saw.
+## 2. Context is where cheap models fail
 
-I also built a simple no-LLM rule as the baseline. Two cheap models (flash-lite, gpt-5.4-nano) never beat it. They look fine on the first test. On context they add nothing. Pick a model on accuracy alone and you get a tool that ignores the context you added it for.
+The second skill: change the context, and check that the score moves the right way.
 
-**3. Some models fake it.**
-When a model correctly ignores the "critical data" tag for a crash-only bug, is it reasoning, or just matching the words "denial of service"?
+A Log4Shell 10.0 that nothing can reach should drop to LOW. Seven of the eight models do it. A token leak (CVSS 6.5) on a public site full of user data should rise to HIGH. All eight do.
 
-So I rewrote the descriptions to hide the impact words. One case still works: the model sees that tampering with an audit log is a real problem, with no keyword to lean on. But the crash case breaks: remove the words, and the score jumps back up. It was matching keywords. I almost didn't check.
+Those two are real CVEs, on purpose. The other context tests use made-up CVEs, so no model can lean on a score it already saw.
 
-(Local models: all four I tried were no better than a fixed guess. Not ready for this.)
+Now the baseline. My simple no-LLM rule already does the basic context math. Two cheap models, flash-lite and gpt-5.4-nano, never beat it: they add nothing on top of the rule. They look fine on the first skill, but on context they are useless. So don't pick a model on its accuracy score alone.
 
-**What to run:**
+## 3. Real understanding, or just matching words?
+
+This is the test I almost skipped. When a model lowers the score for a crash-only bug, is it reasoning? Or is it just reacting to the words "denial of service" in the text?
+
+To find out, I removed those impact words from the descriptions and ran it again.
+
+One case survived. For a bug that tampers with an audit log, the model still saw a real problem, with no keyword to help it. That is real understanding.
+
+One case failed. For the crash bug, once the words were gone, the score jumped back up to the maximum. The model was matching words, not thinking.
+
+(Local models: the four I tried were no better than a fixed guess. Not ready for this job.)
+
+## What to run
+
 - **A score you can defend** → claude-sonnet-4-6. Best and most stable.
-- **Cheap and good** → gpt-5.4-mini. Top results for $0.48, but run it a few times; it's not stable.
-- **Rough sorting only** → gemini-2.5-flash-lite. $0.07, but weak on context.
+- **Cheap and good** → gpt-5.4-mini. Top results for $0.48. It is a bit unstable, so run it a few times and take the middle result.
+- **Rough sorting only** → gemini-2.5-flash-lite. Very cheap at $0.07, but weak on context. Use it for a first pass, not for final scores.
 - **Skip** → gpt-5.5 (too expensive) and gpt-5.4-nano.
 
 The [paper](https://github.com/venslabs/vens-benchmark/blob/main/paper/vens-benchmark.pdf) has the full numbers and the limits. The [harness](https://github.com/venslabs/vens-benchmark) is public, so you can test any model, including your own.


### PR DESCRIPTION
Follow-up to #199. This puts the reviewed version of the blog post on main:

- real `##` section headings (were bold text glued to the paragraph)
- a cover image, so the blog index shows a card instead of raw text
- links to CTIBench and an example `config.yaml`, and a one-line bridge explaining the two skills the benchmark measures
- section 3 rewritten, and simpler English throughout for non-native readers