### PR TITLE
docs: align model docs with the benchmark

### DIFF
--- a/docs/concepts/choosing-a-model.md
+++ b/docs/concepts/choosing-a-model.md
@@ -34,7 +34,7 @@ Set the model with the provider's `*_MODEL` env var (`OPENAI_MODEL`, `ANTHROPIC_
 
 Not there yet. Every local model tested (via Ollama: `llama3.2`, `qwen2.5:7b`, `gemma2:9b`, `deepseek-r1:8b`) came out statistically indistinguishable from a constant-guess baseline — their confidence intervals overlap the 1.57 floor — and only the reasoning model engaged the context at all. For context-conditioned scoring today, a small local model is close to not using an LLM.
 
-See the [paper](../assets/vens-benchmark.pdf) for the method, the two showcases (a 10.0 that ends LOW, a 5.3 that ends HIGH), and where the models — and the test itself — break.
+See the [paper](../assets/vens-benchmark.pdf) for the method, the two showcases (a 10.0 that ends LOW, a 6.5 that ends HIGH), and where the models (and the test itself) break.
 
 ---
 

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -73,7 +73,7 @@ Vens itself is an MIT-ish Apache 2.0 Go binary — it holds no data and signs no
 
 ## 7. Score quality drops on models below ~7B parameters
 
-Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under 7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. `llama3.1:70b` and larger cloud models (gpt-5.4-mini, claude-sonnet-4-6, gemini-2.5-flash) are the sweet spot; lighter models are usable with `--llm-batch-size 3–5` but with lower quality.
+Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under 7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. `llama3.1:70b` and larger cloud models (gpt-5.4-mini, claude-sonnet-4-6, gemini-2.5-flash-lite) are the sweet spot; lighter models are usable with `--llm-batch-size 3–5` but with lower quality.
 
 This is a fundamental constraint of today's open-weight model landscape — if you need air-gapped + high quality, plan for a beefy GPU box.
 


### PR DESCRIPTION
Two small doc fixes found by a vens <-> vens-benchmark consistency check:

- `limitations.md` listed `gemini-2.5-flash` as a sweet-spot cloud model, but the benchmark shows it is Pareto-dominated by `gemini-2.5-flash-lite` (worse MAD and ~5x the cost). Now matches `choosing-a-model.md` and the blog.
- `choosing-a-model.md` cited the med->high showcase as CVSS 5.3; the axios CVE is 6.5 (the 5.3 came from a stale analysis-script header).

The model-default gaps from the same check were already handled by #197.
