### PR TITLE
docs: refresh limitations, privacy and alternatives

### DIFF
--- a/docs/concepts/alternatives.md
+++ b/docs/concepts/alternatives.md
@@ -34,12 +34,12 @@ The two are not mutually exclusive: you can use Vens to rank, triage the top N, 
 
 ## LLM-based triage tooling
 
-**[vexllm](https://github.com/AkihiroSuda/vexllm)** — predecessor and direct inspiration for Vens. vexllm uses an LLM to mark CVEs as `not_affected` in OpenVEX format.
+**[vexllm](https://github.com/AkihiroSuda/vexllm)** (now archived) — the predecessor and direct inspiration for Vens. vexllm used an LLM to mark CVEs as `not_affected` in OpenVEX format.
 
 - vexllm outputs a binary **affected / not_affected** per CVE — yes/no suppression.
 - Vens outputs a **continuous OWASP Risk Rating score (0–81)** per CVE, with the four OWASP factors, and maps it to the CycloneDX VEX severity bucket.
 
-They answer different questions. vexllm answers "should I hide this CVE?"; Vens answers "how urgent is it compared to the others?". If you only need to suppress noise in a dashboard, vexllm may be enough. If you need a prioritized patch queue and CI gating by contextual risk, Vens is closer to the goal.
+They answer different questions. vexllm answers "should I hide this CVE?"; Vens answers "how urgent is it compared to the others?". vexllm is now archived and unmaintained: it proved the LLM-triage idea, but for anything you set up today Vens is the maintained path, and if you need a prioritized patch queue and CI gating by contextual risk it is also the closer fit.
 
 Vens' prompt structure and output-handler pattern are adapted from vexllm — credit is in the code comments.
 

--- a/docs/concepts/limitations.md
+++ b/docs/concepts/limitations.md
@@ -22,9 +22,11 @@ You can also pass [`--attest`](../reference/generate.md#--attest) to write a CDX
 
 ---
 
-## 2. No published benchmark or calibration study
+## 2. Benchmarked for model choice, not calibrated to your outcomes
 
-We do not claim a measured accuracy number against a ground-truth dataset. There is no "Vens scores agreed with human experts N% of the time" study. Treat Vens scores as a **ranking aid over CVSS alone**, not as a certified risk assessment.
+There is now a public benchmark, [vens-benchmark](https://github.com/venslabs/vens-benchmark), measuring how 12 LLMs do the vens scoring task: predicting a CVE's severity and reacting when the context changes. It is what backs the model advice in [Choosing a model](choosing-a-model.md) and the [writeup](../blog/posts/which-llm-should-score-your-cves.md).
+
+What it does **not** give you is a calibration study proving Vens' priorities match expert human judgment on your systems. It tells you which model to run, not "Vens agreed with a human N% of the time" on your backlog. Treat Vens scores as a **ranking aid over CVSS alone**, not a certified risk assessment.
 
 How to use it responsibly:
 
@@ -34,7 +36,7 @@ How to use it responsibly:
 
 ---
 
-## 3. Score quality depends entirely on user-provided context
+## 3. Score quality depends on your context and your model
 
 `config.yaml` is a trust input. If you:
 
@@ -42,7 +44,9 @@ How to use it responsibly:
 - mark `waf: true` when you have no WAF,
 - leave `notes` empty on a complex deployment,
 
-— the LLM has no way of knowing, and the scores will silently reflect your bad data. There is no automated validation of your claims. This is by design (Vens cannot inspect your production), but it is a limitation you should mitigate with [governance](../guides/configuration.md#governing-your-context-file).
+then the LLM has no way of knowing, and the scores will silently reflect your bad data. There is no automated validation of your claims. This is by design (Vens cannot inspect your production), but it is a limitation you should mitigate with [governance](../guides/configuration.md#governing-your-context-file).
+
+Quality also depends on the model you run. A weak model produces weak scores even with perfect context, and the [benchmark](https://github.com/venslabs/vens-benchmark) shows the spread between models is large. See [Choosing a model](choosing-a-model.md) for the ones that hold up.
 
 ---
 
@@ -67,15 +71,17 @@ See [Privacy and data flow](privacy-and-data-flow.md) for the full list of what 
 
 ## 6. No HIPAA BAA or similar legal agreements
 
-Vens itself is an MIT-ish Apache 2.0 Go binary — it holds no data and signs no agreements. If you need a BAA, DPA, or equivalent for a cloud LLM provider, negotiate it directly with the provider on your provider account. For regulated workloads, the safest path is to deploy with Ollama on infrastructure you already have compliance coverage for.
+Vens itself is an MIT-ish Apache 2.0 Go binary — it holds no data and signs no agreements. If you need a BAA, DPA, or equivalent for a cloud LLM provider, negotiate it directly with the provider on your provider account. For regulated workloads, the safest path is to deploy with Ollama on infrastructure you already have compliance coverage for, accepting the local-model quality tradeoff in limitation 7.
 
 ---
 
-## 7. Score quality drops on models below ~7B parameters
+## 7. Local models underperform on this task today
 
-Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under 7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. `llama3.1:70b` and larger cloud models (gpt-5.4-mini, claude-sonnet-4-6, gemini-2.5-flash-lite) are the sweet spot; lighter models are usable with `--llm-batch-size 3–5` but with lower quality.
+Vens asks the LLM to return structured JSON with four component scores per CVE. Small local models (under ~7B parameters) frequently emit malformed JSON or produce flat, uniform scores regardless of input. Smaller batches (`--llm-batch-size 3–5`) cut down the malformed JSON, but they do not fix the quality gap.
 
-This is a fundamental constraint of today's open-weight model landscape — if you need air-gapped + high quality, plan for a beefy GPU box.
+Larger local models are not a safe fix either: in the [benchmark](https://github.com/venslabs/vens-benchmark), the local models tried through Ollama all scored at or below a constant-guess baseline on the context task. If you need air-gapped **and** high quality, that is a real gap right now.
+
+On cloud, the benchmark-backed picks are `claude-sonnet-4-6` (most accurate and stable) and `gpt-5.4-mini` (best value, run it a few times); `gemini-2.5-flash-lite` is fine only for rough triage. See [Choosing a model](choosing-a-model.md).
 
 ---
 

--- a/docs/concepts/privacy-and-data-flow.md
+++ b/docs/concepts/privacy-and-data-flow.md
@@ -49,11 +49,13 @@ That is the complete list. Nothing else from the scanner report is forwarded.
 The `notes` field in `config.yaml` is free-form text that you author. It is designed to let you describe architecture and deployment context in plain English so the LLM can make better scoring decisions. **It is sent verbatim** to the configured LLM provider.
 
 **Do:**
+
 - Describe architecture at a level you would share with a security vendor.
 - Mention technologies, frameworks, deployment patterns.
 - Note compensating controls and the services the system talks to.
 
 **Do not:**
+
 - Paste secrets, API keys, tokens, passwords, or any credential material.
 - Name internal systems by sensitive codename if that would violate an NDA or classification policy.
 - Include customer data, PHI, PII, or personal identifiers.


### PR DESCRIPTION
Refresh the three concept pages against the benchmark and current state:

- limitations #2: the benchmark exists now (venslabs/vens-benchmark). Reframed as "benchmarked for model choice, not a calibration study for your outcomes".
- limitations #3: score quality also depends on the model, not just context.
- limitations #7: drop the inaccurate "llama3.1:70b is the sweet spot". The benchmark found the local models at or below a constant-guess baseline; cloud picks are sonnet / gpt-5.4-mini, flash-lite for rough triage only.
- privacy: fix the Do / Do not lists (a missing blank line stopped them rendering as lists).
- alternatives: mark vexllm archived.
