### PR TITLE
ci: approve dependabot patch/minor PRs so auto-merge can complete

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,14 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      # Auto-merge patch and minor bumps once CI is green; leave majors for a human.
+      # Patch/minor only, majors stay manual. Approve because main requires a review.
+      - name: Approve
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge
         if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Follow-up to #207. main's ruleset requires one approving review, so enabling auto-merge alone leaves Dependabot PRs stuck. This adds a bot approval on patch/minor bumps. It re-runs on every rebase (which dismisses stale reviews), so it re-approves itself.