### PR TITLE
ci: only auto-merge dependabot PRs that have a milestone

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,13 +1,17 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    # milestoned so assigning the milestone re-triggers and unblocks the merge
+    types: [opened, synchronize, reopened, milestoned]
 
 permissions:
   contents: read
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # gate on the PR author, not the actor, so a human adding the milestone still runs it
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -22,16 +26,17 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      # Patch/minor only, majors stay manual. Approve because main requires a review.
+      # Auto-merge patch/minor, and only once the PR has a milestone. Majors and
+      # unmilestoned PRs stay manual. Approve because main requires a review.
       - name: Approve
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,17 +26,37 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
+      # Only Dependabot itself or a maintainer (admin/maintain) may drive the merge,
+      # so a mere write/triage collaborator can't greenlight via a milestone or push.
+      - name: Trusted trigger?
+        id: trust
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          role=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.role_name' 2>/dev/null || echo none)
+          if [ "$role" = "admin" ] || [ "$role" = "maintain" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Auto-merge patch/minor, and only once the PR has a milestone. Majors and
       # unmilestoned PRs stay manual. Approve because main requires a review.
       - name: Approve
-        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null
+        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null && steps.trust.outputs.ok == 'true'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null
+        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && github.event.pull_request.milestone != null && steps.trust.outputs.ok == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Scopes the milestone requirement to auto-merge only, not a repo-wide required check (human PRs untouched).

The bot now approves + enables auto-merge only when the dependabot PR has a milestone. Added the milestoned trigger and switched the job gate to the PR author so assigning a milestone re-runs it and unblocks the merge. No milestone = the bot stays hands-off.