### PR TITLE
feat(vexenricher): include OWASP vector in enrich output (fixes #61)

### DIFF
--- a/pkg/vexenricher/enricher.go
+++ b/pkg/vexenricher/enricher.go
@@ -28,6 +28,8 @@ import (
 type VEXEnricher struct {
 	// Map of VulnerabilityID to OWASP Score
 	OWASPScorePerVulnID map[string]float64
+	// Map of VulnerabilityID to OWASP Risk Rating vector string
+	OWASPVectorPerVulnID map[string]string
 }
 
 // New creates a new VEXEnricher from VEX data
@@ -38,7 +40,8 @@ func New(vexData []byte) (*VEXEnricher, error) {
 	}
 
 	enricher := &VEXEnricher{
-		OWASPScorePerVulnID: make(map[string]float64),
+		OWASPScorePerVulnID:  make(map[string]float64),
+		OWASPVectorPerVulnID: make(map[string]string),
 	}
 
 	// Parse VEX vulnerabilities - extract OWASP ratings by Vulnerability ID
@@ -54,10 +57,11 @@ func New(vexData []byte) (*VEXEnricher, error) {
 					continue
 				}
 
-				// Map the score to the vulnerability ID.
+				// Map the score and vector to the vulnerability ID.
 				// Note: if multiple entries exist for the same CVE in VEX,
 				// we take the last one found.
 				enricher.OWASPScorePerVulnID[vuln.ID] = *rating.Score
+				enricher.OWASPVectorPerVulnID[vuln.ID] = rating.Vector
 			}
 		}
 	}
@@ -82,7 +86,8 @@ func (e *VEXEnricher) EnrichReport(ctx context.Context, reportData []byte) (*tri
 			vuln := &result.Vulnerabilities[j]
 
 			if score, ok := e.OWASPScorePerVulnID[vuln.VulnerabilityID]; ok {
-				if e.applyRating(vuln, score) {
+				vector := e.OWASPVectorPerVulnID[vuln.VulnerabilityID]
+				if e.applyRating(vuln, score, vector) {
 					enrichedCount++
 				}
 			}
@@ -96,8 +101,9 @@ func (e *VEXEnricher) EnrichReport(ctx context.Context, reportData []byte) (*tri
 	return &report, nil
 }
 
-// applyRating sets the OWASP score in the vulnerability's Custom field
-func (e *VEXEnricher) applyRating(vuln *trivytypes.DetectedVulnerability, score float64) bool {
+// applyRating sets the OWASP score (and, if present, the OWASP Risk Rating
+// vector) in the vulnerability's Custom field
+func (e *VEXEnricher) applyRating(vuln *trivytypes.DetectedVulnerability, score float64, vector string) bool {
 	if vuln.Custom == nil {
 		vuln.Custom = make(map[string]interface{})
 	}
@@ -110,7 +116,12 @@ func (e *VEXEnricher) applyRating(vuln *trivytypes.DetectedVulnerability, score 
 		return false
 	}
 
-	// Temporary field until Trivy adds an official one
+	// Temporary fields until Trivy adds official ones
 	customMap["owasp_score"] = score
+	if vector != "" {
+		customMap["owasp_vector"] = vector
+	} else {
+		delete(customMap, "owasp_vector")
+	}
 	return true
 }

--- a/pkg/vexenricher/enricher_test.go
+++ b/pkg/vexenricher/enricher_test.go
@@ -72,3 +72,106 @@ func TestEnrichReport_SimpleMapping(t *testing.T) {
 	assert.Equal(t, "CVE-2023-5678", vuln2.VulnerabilityID)
 	assert.Nil(t, vuln2.Custom)
 }
+
+func TestEnrichReport_VectorMapping(t *testing.T) {
+	// Create a mock VEX document with an OWASP rating that carries a vector
+	score := 52.0
+	vector := "SL:7/M:7/O:7/S:7/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7"
+	vex := cdx.BOM{
+		SpecVersion: cdx.SpecVersion1_5,
+		Vulnerabilities: &[]cdx.Vulnerability{
+			{
+				ID: "CVE-2023-1234",
+				Ratings: &[]cdx.VulnerabilityRating{
+					{
+						Method: cdx.ScoringMethodOWASP,
+						Score:  &score,
+						Vector: vector,
+					},
+				},
+			},
+			{
+				ID: "CVE-2023-9999",
+				Ratings: &[]cdx.VulnerabilityRating{
+					{
+						Method: cdx.ScoringMethodOWASP,
+						Score:  &score,
+						// No vector supplied for this one.
+					},
+				},
+			},
+			{
+				ID: "CVE-2023-7777",
+				Ratings: &[]cdx.VulnerabilityRating{
+					{Method: cdx.ScoringMethodOWASP, Score: &score},
+					{
+						Method: cdx.ScoringMethodCVSSv31,
+						Score:  &score,
+						Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+				},
+			},
+		},
+	}
+	vexData, _ := json.Marshal(vex)
+
+	// Create a mock Trivy report
+	report := trivytypes.Report{
+		Results: trivytypes.Results{
+			{
+				Target: "test-target",
+				Vulnerabilities: []trivytypes.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2023-1234",
+						PkgName:         "lib-a",
+					},
+					{
+						VulnerabilityID: "CVE-2023-9999",
+						PkgName:         "lib-b",
+					},
+					{
+						VulnerabilityID: "CVE-2023-7777",
+						PkgName:         "lib-c",
+					},
+				},
+			},
+		},
+	}
+	reportData, _ := json.Marshal(report)
+
+	enricher, err := New(vexData)
+	require.NoError(t, err)
+
+	enrichedReport, err := enricher.EnrichReport(context.Background(), reportData)
+	require.NoError(t, err)
+
+	require.Len(t, enrichedReport.Results, 1)
+	require.Len(t, enrichedReport.Results[0].Vulnerabilities, 3)
+
+	// First vulnerability has a vector - both fields should be present.
+	vuln1 := enrichedReport.Results[0].Vulnerabilities[0]
+	assert.Equal(t, "CVE-2023-1234", vuln1.VulnerabilityID)
+	require.NotNil(t, vuln1.Custom)
+	customMap1 := vuln1.Custom.(map[string]interface{})
+	assert.Equal(t, score, customMap1["owasp_score"])
+	assert.Equal(t, vector, customMap1["owasp_vector"])
+
+	// Second vulnerability has no vector - only the score should be present.
+	vuln2 := enrichedReport.Results[0].Vulnerabilities[1]
+	assert.Equal(t, "CVE-2023-9999", vuln2.VulnerabilityID)
+	require.NotNil(t, vuln2.Custom)
+	customMap2 := vuln2.Custom.(map[string]interface{})
+	assert.Equal(t, score, customMap2["owasp_score"])
+	assert.NotContains(t, customMap2, "owasp_vector")
+
+	// Third vulnerability's OWASP rating has no vector, but a sibling
+	// CVSSv31 rating on the same CVE does. The CVSS vector must not leak
+	// into owasp_vector: score and vector always come from the same
+	// OWASP rating.
+	vuln3 := enrichedReport.Results[0].Vulnerabilities[2]
+	assert.Equal(t, "CVE-2023-7777", vuln3.VulnerabilityID)
+	require.NotNil(t, vuln3.Custom)
+	customMap3 := vuln3.Custom.(map[string]interface{})
+	assert.Equal(t, score, customMap3["owasp_score"])
+	assert.NotContains(t, customMap3, "owasp_vector")
+}


### PR DESCRIPTION
`vens enrich` now emits `Custom.owasp_vector` alongside `owasp_score` — the OWASP Risk Rating vector string that explains how the score was derived, taken from the same CycloneDX `VulnerabilityRating` the score already comes from (`vens generate` writes it at generator.go:262, so it's genuinely already in the VEX document, per the issue).

Implementation mirrors the score path exactly: an `OWASPVectorPerVulnID` map populated in `New()` with the same last-one-wins semantics, applied in `applyRating`. One design choice the issue left open, resolved from your own precedent: when a rating carries no vector, the key is **omitted** rather than set to `""` — same as `Score == nil` being skipped rather than stored as zero, keeping both fields symmetric in "only add if the data exists". Easy to flip if you prefer.

Tests: a vector-mapping test (proven to fail without the implementation — expected the vector string, got `nil`), plus the no-vector-omits-key case; `pkg/vexenricher` coverage 85.7% → 87.2%. Gates green: `gofmt -s` / `goimports` clean, `golangci-lint run` 0 issues, `go test -covermode=atomic -race ./pkg/...` all ok, all 8 `TestScript` scenarios pass.

One aside noticed while running your gates: CONTRIBUTING documents `make fmt` / `make lint`, but the Makefile on main has neither target — ran the underlying tools directly instead. Happy to PR the Makefile targets or a CONTRIBUTING tweak if you'd like.

---
Generated by Claude Fable 5 (brief, review), Claude Sonnet 4.6 (implementation)