### PR TITLE
Make GOLANGCI_VERSION the single source of truth for the linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,14 @@ jobs:
       - name: Integration tests
         run: go test -v ./cmd/vens/... -run TestScript
 
+      - name: Resolve golangci-lint version
+        id: golangci
+        run: echo "version=$(make print-golangci-version)" >> "$GITHUB_OUTPUT"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
+          version: ${{ steps.golangci.outputs.version }}
           args: --timeout=10m --verbose
 
       - run: go install ./cmd/vens

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,6 @@ repos:
   rev: v8.16.3
   hooks:
   - id: gitleaks
-- repo: https://github.com/golangci/golangci-lint
-  rev: v1.52.2
-  hooks:
-  - id: golangci-lint
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
   rev: 3.0.0
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ make lint
 ## Code style
 
 - **Go formatting** — everything must pass `gofmt -s` and `goimports`. The Makefile target `make fmt` does both; run it before submitting a change.
-- **Linting** — `make lint` runs `golangci-lint run --timeout=10m --verbose`. Fix or justify every finding before asking for review.
+- **Linting** — `make lint` runs golangci-lint, pinned via `GOLANGCI_VERSION` in the Makefile (the single source of truth for the linter version). Fix or justify every finding before asking for review.
 - **Package layout** — follow the structure already in `pkg/` and `cmd/vens/commands/`. New LLM providers live under `pkg/llm/`, new scanners under `pkg/scanner/`, new output formats under `pkg/outputhandler/`.
 - **Error wrapping** — wrap with `fmt.Errorf("context: %w", err)` so error chains stay inspectable. Do not discard errors silently.
 - **Logging** — use `log/slog` with the keyed form (`slog.InfoContext(ctx, "message", "key", value)`), never `log.Printf`.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ export CGO_ENABLED ?= 0
 GO ?= go
 GO_LDFLAGS ?= -s -w -X $(VERSION_SYMBOL)=$(VERSION)
 GO_BUILD ?= $(GO) build -trimpath -ldflags="$(GO_LDFLAGS)"
+# Bump by hand when a newer golangci-lint v2 lands: Dependabot tracks the
+# action SHA and go modules, not this pin, so it will otherwise go stale silently.
 GOLANGCI_VERSION ?= v2.12.2
 GOPATH_BIN := $(shell $(GO) env GOBIN)
 ifeq ($(GOPATH_BIN),)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export CGO_ENABLED ?= 0
 GO ?= go
 GO_LDFLAGS ?= -s -w -X $(VERSION_SYMBOL)=$(VERSION)
 GO_BUILD ?= $(GO) build -trimpath -ldflags="$(GO_LDFLAGS)"
+GOLANGCI_VERSION ?= v2.12.2
 GOPATH_BIN := $(shell $(GO) env GOBIN)
 ifeq ($(GOPATH_BIN),)
 GOPATH_BIN := $(shell $(GO) env GOPATH)/bin
@@ -33,8 +34,12 @@ fmt:
 
 .PHONY: lint
 lint:
-	@PATH="$(GOPATH_BIN):$$PATH" command -v golangci-lint >/dev/null 2>&1 || $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@PATH="$(GOPATH_BIN):$$PATH" command -v golangci-lint >/dev/null 2>&1 || $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 	PATH="$(GOPATH_BIN):$$PATH" golangci-lint run --timeout=10m --verbose
+
+.PHONY: print-golangci-version
+print-golangci-version:
+	@echo $(GOLANGCI_VERSION)
 
 .PHONY: _output/bin/vens
 _output/bin/vens:


### PR DESCRIPTION
Fixes #223.

The golangci-lint invocation was declared in four places that disagreed, so `make lint` couldn't reproduce CI:

- `Makefile` installed `@latest` (whatever v2 was newest that day)
- `.github/workflows/main.yml` took its version from the action's default (no `version:` input)
- `CONTRIBUTING.md` respelled the flags a third time
- `.pre-commit-config.yaml` pinned golangci-lint **v1.52.2** (a v1, incompatible with the above), wired to nothing

This makes a single **`GOLANGCI_VERSION`** variable in the Makefile the one source of truth:

- **Makefile** — `GOLANGCI_VERSION ?= v2.12.2` (the current latest v2); the `lint` target installs that version instead of `@latest`; a new `print-golangci-version` target exposes it.
- **Workflow** — a `Resolve golangci-lint version` step reads it from the Makefile (`make print-golangci-version`) and feeds it to `golangci-lint-action`'s `version:` input, so CI and `make lint` run the exact same linter.
- **CONTRIBUTING** — points at `make lint` instead of respelling the version/flags.
- **.pre-commit-config.yaml** — drops the orphaned, incompatible v1.52.2 golangci-lint hook (nothing ran it); the other hooks (gitleaks, shellcheck, whitespace) are untouched.

### Design choices (happy to change either)

1. **Makefile variable over a go.mod tool directive.** You flagged that the `go get -tool` route drags golangci-lint's dependency tree into the module graph — I agree that's the bigger downside, so I kept the linter out of the module graph. If you'd rather go the tool-directive way, I'll redo it.
2. **`.pre-commit-config.yaml`: removed only the golangci-lint hook, kept the file.** That surgically eliminates the fourth conflicting version source while preserving the still-valid hooks. But since nothing currently runs pre-commit at all, you may prefer to **delete the whole file** or **wire it into CI** instead — your call, tell me which and I'll adjust.

### Verification

- `make print-golangci-version` → `v2.12.2`
- `make lint` → `0 issues.` (golangci-lint 2.12.2), rc=0 — reproduces CI locally
- `make test` → all packages PASS, rc=0
- `go build ./...` → rc=0
- Workflow YAML validates

One known limitation, unchanged from before: the `lint` target's `command -v golangci-lint` guard skips the install if *some* golangci-lint is already on `PATH`, so a contributor with a different version pre-installed won't be auto-corrected to the pinned one. I left the guard as-is to match the reinstall-avoidance behaviour from #222; if you'd like `make lint` to strictly enforce the pinned version, that's a small follow-up.

---
Generated by Claude Opus 4.8 (brief, review), Kimi K2.7 Code (implementation)
