### PR TITLE
fix(generate): write output atomically via temp file + rename

### DIFF
--- a/cmd/vens/commands/generate/generate.go
+++ b/cmd/vens/commands/generate/generate.go
@@ -21,7 +21,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -248,21 +250,43 @@ func action(cmd *cobra.Command, args []string) error {
 	}
 
 	// Flags are validated and the report has parsed; only now is it safe to
-	// create (and truncate) the output file.
-	outputW, err := os.Create(outputPath)
+	// prepare the output. Write to a temp file in the destination directory
+	// and rename it into place only on success, so a failure during
+	// generation never truncates an existing output file.
+	outputW, err := tempOutputFile(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}
-	defer outputW.Close() //nolint:errcheck
+	tmpPath := outputW.Name()
+	committed := false
+	defer func() {
+		outputW.Close() //nolint:errcheck
+		if !committed {
+			os.Remove(tmpPath) //nolint:errcheck
+		}
+	}()
 
 	h := newHandler(outputW)
 
-	if len(vulns) == 0 {
-		slog.WarnContext(ctx, "No vulnerabilities found in the report")
+	// commit flushes the handler, then atomically moves the temp file into
+	// place. From here on the deferred cleanup must not remove it.
+	commit := func() error {
 		if err := h.Close(); err != nil {
 			return fmt.Errorf("failed to close output: %w", err)
 		}
+		if err := outputW.Close(); err != nil {
+			return fmt.Errorf("failed to close output file: %w", err)
+		}
+		if err := os.Rename(tmpPath, outputPath); err != nil {
+			return fmt.Errorf("failed to move output file into place: %w", err)
+		}
+		committed = true
 		return nil
+	}
+
+	if len(vulns) == 0 {
+		slog.WarnContext(ctx, "No vulnerabilities found in the report")
+		return commit()
 	}
 
 	slog.InfoContext(ctx, "Processing vulnerabilities", "count", len(vulns))
@@ -289,27 +313,66 @@ func action(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to generate risk scores: %w", err)
 	}
 
-	if err := h.Close(); err != nil {
+	if err := commit(); err != nil {
 		return err
 	}
 
 	if attestor != nil && attestor.BatchCount() > 0 {
 		atPath := attestation.SiblingPath(outputPath)
-		atW, err := os.Create(atPath)
+		atW, err := tempOutputFile(atPath)
 		if err != nil {
 			return fmt.Errorf("failed to create attestation file %q: %w", atPath, err)
 		}
+		atTmpPath := atW.Name()
+		atCommitted := false
+		defer func() {
+			if !atCommitted {
+				atW.Close()          //nolint:errcheck
+				os.Remove(atTmpPath) //nolint:errcheck
+			}
+		}()
 		if err := attestor.Write(atW); err != nil {
-			atW.Close() //nolint:errcheck
 			return fmt.Errorf("failed to write attestation: %w", err)
 		}
 		if err := atW.Close(); err != nil {
 			return fmt.Errorf("failed to close attestation file %q: %w", atPath, err)
 		}
+		if err := os.Rename(atTmpPath, atPath); err != nil {
+			return fmt.Errorf("failed to move attestation file into place: %w", err)
+		}
+		atCommitted = true
 		slog.InfoContext(ctx, "Attestation written", "path", atPath, "batches", attestor.BatchCount())
 	}
 
 	return nil
+}
+
+// tempOutputFile creates a temp file next to outputPath (same directory, so
+// the later os.Rename stays on one filesystem and is atomic). The caller is
+// responsible for closing, renaming, or removing it.
+func tempOutputFile(outputPath string) (*os.File, error) {
+	tmp, err := os.CreateTemp(filepath.Dir(outputPath), ".vens-*.tmp")
+	if err != nil {
+		return nil, err
+	}
+	if err := tmp.Chmod(outputFileMode(outputPath)); err != nil {
+		tmp.Close()           //nolint:errcheck
+		os.Remove(tmp.Name()) //nolint:errcheck
+		return nil, err
+	}
+	return tmp, nil
+}
+
+// outputFileMode reports the permissions the output file should have: the
+// destination's existing mode when it already exists, otherwise the
+// 0666-before-umask mode os.Create would have produced.
+func outputFileMode(outputPath string) os.FileMode {
+	if fi, err := os.Stat(outputPath); err == nil {
+		return fi.Mode().Perm()
+	}
+	umask := syscall.Umask(0)
+	syscall.Umask(umask)
+	return 0o666 &^ os.FileMode(umask)
 }
 
 // extractSBOMMetadata extracts UUID and version from flags.

--- a/cmd/vens/testdata/script/generate_atomic_output.txt
+++ b/cmd/vens/testdata/script/generate_atomic_output.txt
@@ -1,0 +1,73 @@
+# A failure DURING generation (e.g. an LLM error mid-run) must not truncate
+# an existing output file: vens writes to a temp file in the destination
+# directory and only renames it into place on success.
+
+# Produce a valid output file first
+exec vens generate --llm=mock --config-file=config.yaml --sbom-serial-number=urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 report.json out.cdx.json
+cp out.cdx.json golden.cdx.json
+
+# Force the mock LLM to fail mid-generation. The pre-existing output file
+# must survive byte-identical.
+env VENS_MOCK_LLM_FAIL=1
+! exec vens generate --llm=mock --config-file=config.yaml --sbom-serial-number=urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 report.json out.cdx.json
+stderr 'failed to generate risk scores'
+cmp golden.cdx.json out.cdx.json
+
+# A failed run must not create a previously missing output file either,
+# and no temp file may be left behind.
+! exec vens generate --llm=mock --config-file=config.yaml --sbom-serial-number=urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 report.json missing.cdx.json
+stderr 'failed to generate risk scores'
+! exists missing.cdx.json
+! exec sh -c 'ls .vens-*.tmp'
+
+# With the failure injection unset, generation succeeds again and overwrites
+# the output normally (serialNumber and timestamp differ per run, so check
+# content rather than bytes).
+env VENS_MOCK_LLM_FAIL=
+exec vens generate --llm=mock --config-file=config.yaml --sbom-serial-number=urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79 report.json out.cdx.json
+json-contains out.cdx.json '"specVersion": "1.6"'
+json-contains out.cdx.json '"CVE-2024-1234"'
+
+-- config.yaml --
+project:
+  name: "test-project"
+  description: "Test project for integration tests"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+-- report.json --
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2024-01-15T10:00:00Z",
+  "ArtifactName": "nginx:1.25",
+  "ArtifactType": "container_image",
+  "Results": [
+    {
+      "Target": "nginx:1.25 (debian 12.4)",
+      "Class": "os-pkgs",
+      "Type": "debian",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-1234",
+          "PkgID": "openssl@3.0.11-1~deb12u2",
+          "PkgName": "openssl",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/debian/openssl@3.0.11-1~deb12u2?arch=amd64&distro=debian-12.4"
+          },
+          "InstalledVersion": "3.0.11-1~deb12u2",
+          "FixedVersion": "3.0.13-1~deb12u1",
+          "Status": "fixed",
+          "Title": "OpenSSL: Buffer overflow in SSL_select_next_proto",
+          "Description": "A buffer overflow vulnerability in OpenSSL.",
+          "Severity": "HIGH",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://security-tracker.debian.org/tracker/CVE-2024-1234"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/testutil/mockllm.go
+++ b/internal/testutil/mockllm.go
@@ -18,12 +18,18 @@ package testutil
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 
 	"github.com/venslabs/vens/pkg/llm"
 )
+
+// FailEnv, when set to a non-empty value, makes Generate fail. Integration
+// tests use it to exercise error paths that only surface during generation.
+const FailEnv = "VENS_MOCK_LLM_FAIL"
 
 type MockLLM struct{}
 
@@ -47,6 +53,10 @@ type llmOutput struct {
 // Generate returns deterministic scores for every vulnId found in the human
 // prompt, so integration tests stay reproducible without a real provider.
 func (m *MockLLM) Generate(ctx context.Context, req llm.Request) (string, error) {
+	if os.Getenv(FailEnv) != "" {
+		return "", errors.New("mockllm: forced failure (" + FailEnv + " is set)")
+	}
+
 	vulnIDs, err := extractVulnIDs(req.Human)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

Writes generate's output atomically so a failure mid-generation can't destroy an existing file.

## Changes

- `cmd/vens/commands/generate/generate.go` (+71/−8) — `os.CreateTemp(filepath.Dir(outputPath), ".vens-*.tmp")` puts the temp alongside the destination (same filesystem, so the rename is atomic and can't hit `EXDEV`); after the handler closes, `os.Rename` moves it into place. A deferred cleanup removes the temp on any error return or panic, guarded by a `committed` flag set only after a successful rename, so it can never delete the file it just moved. The attestation sidecar gets the same treatment.
- `internal/testutil/mockllm.go` (+10) — a `VENS_MOCK_LLM_FAIL` env var to inject an LLM failure; opt-in and inert in normal runs.
- `cmd/vens/testdata/script/generate_atomic_output.txt` (+73) — seeds an existing output, forces a failure mid-generation, and asserts the file is byte-identical afterwards.

Permissions are preserved: if the destination already exists its mode is kept; a new file gets `0666 &^ umask`, exactly what `os.Create` produced before.

## Testing

`go build ./...`, `go test -count=1 -covermode=atomic -race ./pkg/...`, `go test -count=1 ./cmd/vens/... -run TestScript`, `make lint` (0 issues), `gofmt -l` clean.

The new script test pins the behavior rather than just passing: with the fix reverted it fails at the compare (`golden.cdx.json and out.cdx.json differ`, the file having been truncated to 0 bytes).

## Breaking Changes

**This costs Windows compilability.** Reading the umask uses `syscall.Umask`, which doesn't exist on Windows, so `GOOS=windows go build ./...` will now fail on this package. Your CI is ubuntu-only and there is no cross-compiled release, so nothing here breaks in practice — but I didn't want to introduce it quietly.

Happy to split it into `umask_unix.go` / `umask_other.go` behind build tags, with the non-Unix one just returning `0666`, if you want the package to stay buildable everywhere. Say the word and I'll push it.

Fixes #236

## Footer

Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)