### PR TITLE
docs(blog): repatriate the Medium and dev.to posts into the site blog

### DIFF
--- a/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
+++ b/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
@@ -15,9 +15,9 @@ Except that CVE targets a feature you don't even use. Two days gone for nothing.
 
 CVSS tells you the technical severity of the bug. Not the real risk for *your* system.
 
-## Context, finally
+## What vens does
 
-[vens](https://github.com/venslabs/vens) reads your scan output plus a short file describing your system (exposure, sensitive data, compliance, security controls) and computes a realistic OWASP Risk Rating with an LLM. The result tells you what to patch first.
+[vens](https://github.com/venslabs/vens) reads your scan output plus a short file describing your system (exposure, sensitive data, compliance, security controls) and computes an OWASP Risk Rating with an LLM. The result tells you what to patch first.
 
 ## How it works
 
@@ -45,24 +45,27 @@ project:
   description: "Customer-facing REST API"
 
 context:
-  exposure: "internet"                    # internet-accessible
+  exposure: "internet"                    # internal | private | internet
   data_sensitivity: "high"                # customer PII
   business_criticality: "high"            # business-critical service
   compliance_requirements: ["GDPR", "SOC2"]
   controls:
-    waf: true                             # WAF in front
-    ids: true                             # IDS in place
+    waf: true
+    ids: true
 ```
 
 ### 4. Run the contextual analysis
 
 ```bash
 export OPENAI_API_KEY="sk-..."
-export OPENAI_MODEL="gpt-4o"
-trivy vens generate --config-file config.yaml report.json output.vex.json
+export OPENAI_MODEL="gpt-5.4-mini"
+
+# serialNumber of the SBOM paired with this scan; any urn:uuid: works for a first run
+SBOM_UUID="urn:uuid:$(uuidgen | tr '[:upper:]' '[:lower:]')"
+trivy vens generate --config-file config.yaml --sbom-serial-number "$SBOM_UUID" report.json output.vex.json
 ```
 
-## A VEX that speaks your language
+## The output
 
 Here is an extract of what vens generates:
 
@@ -100,15 +103,6 @@ Here is an extract of what vens generates:
 ```
 
 Same two CVEs, ranked by what they mean for your deployment rather than by a context-free base score.
-
-## The flow
-
-```
-Trivy scan       ->  107 CVEs with CVSS scores
-vens + LLM       ->  scores each CVE with YOUR context
-OWASP scores     ->  Risk = Likelihood x Impact
-prioritized list ->  fix what matters for you
-```
 
 ## Try it
 

--- a/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
+++ b/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
@@ -1,0 +1,120 @@
+---
+date: 2026-02-04
+categories:
+  - Introduction
+slug: stop-patching-vulnerabilities-that-dont-matter
+---
+
+# Stop patching vulnerabilities that don't matter to you
+
+Monday, 9 AM, coffee in hand. You open the Trivy report: **107 vulnerabilities**. You sort by CVSS, a **9.8 CRITICAL** sits at the top, and the emergency meeting starts.
+
+<!-- more -->
+
+Except that CVE targets a feature you don't even use. Two days gone for nothing. Meanwhile a **5.3 MEDIUM** sits quietly further down: it exposes customer data, and you are under GDPR. That was the real problem.
+
+CVSS tells you the technical severity of the bug. Not the real risk for *your* system.
+
+## Context, finally
+
+[vens](https://github.com/venslabs/vens) reads your scan output plus a short file describing your system (exposure, sensitive data, compliance, security controls) and computes a realistic OWASP Risk Rating with an LLM. The result tells you what to patch first.
+
+## How it works
+
+### 1. Install
+
+vens is an [official Trivy plugin](https://aquasecurity.github.io/trivy-plugin-index/):
+
+```bash
+go install github.com/venslabs/vens/cmd/vens@latest
+# or as a Trivy plugin
+trivy plugin install github.com/venslabs/vens
+```
+
+### 2. Scan as usual
+
+```bash
+trivy image python:3.11-slim --format json --output report.json
+```
+
+### 3. Describe your system in a [`config.yaml`](https://github.com/venslabs/vens/blob/main/examples/quickstart/config.yaml)
+
+```yaml
+project:
+  name: "my-api"
+  description: "Customer-facing REST API"
+
+context:
+  exposure: "internet"                    # internet-accessible
+  data_sensitivity: "high"                # customer PII
+  business_criticality: "high"            # business-critical service
+  compliance_requirements: ["GDPR", "SOC2"]
+  controls:
+    waf: true                             # WAF in front
+    ids: true                             # IDS in place
+```
+
+### 4. Run the contextual analysis
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export OPENAI_MODEL="gpt-4o"
+trivy vens generate --config-file config.yaml report.json output.vex.json
+```
+
+## A VEX that speaks your language
+
+Here is an extract of what vens generates:
+
+```json
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "vulnerabilities": [
+    {
+      "id": "CVE-2026-0915",
+      "ratings": [
+        {
+          "score": 45.5,
+          "severity": "high",
+          "method": "OWASP",
+          "vector": "SL:7/M:7/O:7/S:7/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7"
+        }
+      ]
+    },
+    {
+      "id": "CVE-2019-1010023",
+      "ratings": [
+        {
+          "score": 10,
+          "severity": "low",
+          "method": "OWASP",
+          "vector": "SL:3/M:3/O:3/S:3/ED:2/EE:2/A:2/ID:7/LC:4/LI:4/LAV:4/LAC:4/FD:4/RD:4/NC:4/PV:4"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Same two CVEs, ranked by what they mean for your deployment rather than by a context-free base score.
+
+## The flow
+
+```
+Trivy scan       ->  107 CVEs with CVSS scores
+vens + LLM       ->  scores each CVE with YOUR context
+OWASP scores     ->  Risk = Likelihood x Impact
+prioritized list ->  fix what matters for you
+```
+
+## Try it
+
+- GitHub: [github.com/venslabs/vens](https://github.com/venslabs/vens)
+- Full example: [examples/quickstart](https://github.com/venslabs/vens/tree/main/examples/quickstart)
+- License: Apache 2.0, contributions welcome
+- LLM support: OpenAI, Anthropic, Google, Ollama (local)
+
+*Originally published on [Medium](https://medium.com/@fahed.dorgaa/vens-stop-patching-vulnerabilities-that-dont-matter-to-you-64337b9468a5).*

--- a/docs/blog/posts/vens-action-rerank-cves-in-ci.md
+++ b/docs/blog/posts/vens-action-rerank-cves-in-ci.md
@@ -11,7 +11,7 @@ If you run Trivy or Grype in CI and triage the output by CVSS, this is the thing
 
 <!-- more -->
 
-## Quick recap
+## What it does
 
 Trivy and Grype hand you a list of CVEs. CVSS is a score in a vacuum: it doesn't know whether a service runs in a private subnet behind mTLS, or sits on the open internet handling payment cards. [vens](https://github.com/venslabs/vens) reads your scan output plus a YAML describing the service (exposure, data sensitivity, business criticality, controls, compliance, ...), runs every CVE through an LLM with that context, and emits a CycloneDX VEX with OWASP Risk Rating scores. You gate the build on those instead.
 
@@ -20,7 +20,7 @@ Trivy and Grype hand you a list of CVEs. CVSS is a score in a vacuum: it doesn't
 ## What you need
 
 - A Trivy or Grype JSON report (you're probably running one of these already).
-- A `.vens/config.yaml`. Three context fields are the floor; the full annotated reference is in [`examples/quickstart/config.yaml`](https://github.com/venslabs/vens/blob/main/examples/quickstart/config.yaml).
+- A `.vens/config.yaml`. Three context fields are the floor (see below).
 - An LLM API key: OpenAI, Anthropic, Google, or a self-hosted Ollama.
 - The `serialNumber` of your CycloneDX SBOM (or an ad-hoc one, see below).
 
@@ -73,18 +73,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Trivy scan
-        run: trivy image python:3.11-slim --format json --output report.json
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: python:3.11-slim
+          format: json
+          output: report.json
 
       - name: vens
         id: vens
-        uses: venslabs/vens-action@v0.1.0
+        uses: venslabs/vens-action@v0.2.0
         with:
-          version: v0.3.2
+          version: v0.4.0
           config-file: .vens/config.yaml
           input-report: report.json
           sbom-serial-number: ${{ vars.SBOM_SERIAL }}
           llm-provider: openai
-          llm-model: gpt-4o
+          llm-model: gpt-5.4-mini
           llm-api-key: ${{ secrets.OPENAI_API_KEY }}
           fail-on-severity: critical
           enrich: "true"
@@ -97,7 +101,7 @@ jobs:
             ${{ steps.vens.outputs.enriched-report }}
 ```
 
-Each run gives you a CycloneDX VEX (`vex-file`), your original Trivy report annotated with `Custom.owasp_score` (`enriched-report`, when `enrich: true`), and per-severity counts as step outputs (`count-critical`, `count-high`, ...). Pipe the counts into dashboards, PR comments, whatever you already do with scan metrics.
+Each run gives you a CycloneDX VEX (`vex-file`), your original Trivy report annotated with `Custom.owasp_score` and `Custom.owasp_vector` (`enriched-report`, when `enrich: true`), and per-severity counts as step outputs (`count-critical`, `count-high`, ...). Pipe the counts into dashboards, PR comments, whatever you already do with scan metrics.
 
 `fail-on-severity: critical` makes the step fail if any CVE comes out CRITICAL by OWASP (score >= 60). Drop the line if you just want artifacts and a manual review.
 

--- a/docs/blog/posts/vens-action-rerank-cves-in-ci.md
+++ b/docs/blog/posts/vens-action-rerank-cves-in-ci.md
@@ -1,0 +1,120 @@
+---
+date: 2026-05-28
+categories:
+  - Guide
+slug: vens-action-rerank-cves-in-ci
+---
+
+# vens-action: reranking Trivy/Grype CVEs by real risk in CI
+
+If you run Trivy or Grype in CI and triage the output by CVSS, this is the thing I wish I'd had two years ago.
+
+<!-- more -->
+
+## Quick recap
+
+Trivy and Grype hand you a list of CVEs. CVSS is a score in a vacuum: it doesn't know whether a service runs in a private subnet behind mTLS, or sits on the open internet handling payment cards. [vens](https://github.com/venslabs/vens) reads your scan output plus a YAML describing the service (exposure, data sensitivity, business criticality, controls, compliance, ...), runs every CVE through an LLM with that context, and emits a CycloneDX VEX with OWASP Risk Rating scores. You gate the build on those instead.
+
+[`vens-action`](https://github.com/venslabs/vens-action) is the GitHub Action wrapper: install, invocation, build gate, packaged as a composite. Here's the minimum to drop it in.
+
+## What you need
+
+- A Trivy or Grype JSON report (you're probably running one of these already).
+- A `.vens/config.yaml`. Three context fields are the floor; the full annotated reference is in [`examples/quickstart/config.yaml`](https://github.com/venslabs/vens/blob/main/examples/quickstart/config.yaml).
+- An LLM API key: OpenAI, Anthropic, Google, or a self-hosted Ollama.
+- The `serialNumber` of your CycloneDX SBOM (or an ad-hoc one, see below).
+
+## The config
+
+The bare minimum:
+
+```yaml
+project:
+  name: "checkout-api"
+context:
+  exposure: "internet"
+  data_sensitivity: "high"
+  business_criticality: "critical"
+```
+
+For scoring that actually reflects your service, fill in the rest: security controls (WAF, IDS, segmentation, ...), compliance requirements, availability target, free-form notes. The annotated reference lives in [`examples/quickstart/config.yaml`](https://github.com/venslabs/vens/blob/main/examples/quickstart/config.yaml). Wrong values mean wrong scores, so this file deserves the same review process as the rest of your code (CODEOWNERS, PR review, the works).
+
+## The SBOM serial number
+
+vens writes a CycloneDX VEX whose `vulnerabilities[].affects[].ref` entries are [BOM-Link](https://cyclonedx.org/capabilities/bomlink/) references: they must point back to the `serialNumber` of the SBOM the scan was produced from.
+
+If you already have a CycloneDX SBOM for the artifact, pull the serial from it:
+
+```bash
+SBOM_UUID=$(jq -r .serialNumber sbom.cdx.json)
+```
+
+If you don't have one yet, generate an ad-hoc serial and reuse it across rescans of the same service so the BOM-Link stays stable:
+
+```bash
+SBOM_UUID="urn:uuid:$(uuidgen | tr '[:upper:]' '[:lower:]')"
+```
+
+Store the value as a repo variable, say `vars.SBOM_SERIAL`. Flag reference: [`vens generate --sbom-serial-number`](https://venslabs.github.io/vens/reference/generate/#-sbom-serial-number-urnuuid).
+
+## The workflow
+
+`.github/workflows/scan.yml`:
+
+```yaml
+name: scan
+on: [push]
+permissions:
+  contents: read
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy scan
+        run: trivy image python:3.11-slim --format json --output report.json
+
+      - name: vens
+        id: vens
+        uses: venslabs/vens-action@v0.1.0
+        with:
+          version: v0.3.2
+          config-file: .vens/config.yaml
+          input-report: report.json
+          sbom-serial-number: ${{ vars.SBOM_SERIAL }}
+          llm-provider: openai
+          llm-model: gpt-4o
+          llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+          fail-on-severity: critical
+          enrich: "true"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vens
+          path: |
+            ${{ steps.vens.outputs.vex-file }}
+            ${{ steps.vens.outputs.enriched-report }}
+```
+
+Each run gives you a CycloneDX VEX (`vex-file`), your original Trivy report annotated with `Custom.owasp_score` (`enriched-report`, when `enrich: true`), and per-severity counts as step outputs (`count-critical`, `count-high`, ...). Pipe the counts into dashboards, PR comments, whatever you already do with scan metrics.
+
+`fail-on-severity: critical` makes the step fail if any CVE comes out CRITICAL by OWASP (score >= 60). Drop the line if you just want artifacts and a manual review.
+
+## Things you'll probably want to tweak
+
+- **Self-hosted models.** `llm-provider: ollama` + `llm-base-url: http://ollama.corp:11434`.
+- **Air-gapped runners.** Build vens yourself and pass `bin-path` instead of `version`. Skips the download and checksum step entirely.
+- **Pin by SHA.** `uses: venslabs/vens-action@<commit-sha>`. Renovate and Dependabot both follow SHA-pinned actions.
+
+## Why I bothered building it
+
+CVSS sorts vulnerabilities like a smoke detector that can't tell if you're cooking or your kitchen is on fire. A 9.8 on an internal service with no PII and no internet exposure is rarely your urgent problem. A 5.4 on the auth path with cleartext token logging probably is. Your team knows the difference, but a spreadsheet per service doesn't scale, and most tools that do contextual scoring are paid SaaS with their own opinions.
+
+vens is OSS, Apache 2.0. The action is a thin composite around the CLI. Issues, feedback, PRs: I read them.
+
+- Action: [github.com/venslabs/vens-action](https://github.com/venslabs/vens-action)
+- CLI: [github.com/venslabs/vens](https://github.com/venslabs/vens)
+- Docs: [venslabs.github.io/vens](https://venslabs.github.io/vens/)
+
+*Originally published on [dev.to](https://dev.to/fahed-dorgaa/vens-action-reranking-trivygrype-cves-by-real-risk-in-ci-1eec).*

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -111,7 +111,7 @@ Open `output.vex.json`. It is a CycloneDX 1.6 BOM (1.6 is the default; pass `--c
       "ratings": [
         {
           "method": "OWASP",
-          "score": 52.0,
+          "score": 45.5,
           "severity": "high",
           "vector": "SL:7/M:7/O:7/S:7/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7"
         }


### PR DESCRIPTION
Brings the two external posts into the docs blog so everything lives in one place.

- Stop patching vulnerabilities that don't matter (Medium, 2026-02-04)
- vens-action: reranking CVEs in CI (dev.to, 2026-05-28)

Matched the existing post's frontmatter and voice (dropped the emoji, kept the content), each links back to the original. Added `Introduction` and `Guide` categories.

Examples track current main: vens `v0.4.0`, vens-action `v0.2.0`, `gpt-5.4-mini`. Fixed two examples that wouldn't run as pasted, the `generate` command was missing the required `--sbom-serial-number`, and the CI workflow never installed Trivy (now via `trivy-action`).

Separate commit also fixes an unrelated pre-existing bug spotted in review: the quickstart VEX example paired its vector with score 52.0, which is wrong, that vector scores 45.5.