### PR TITLE
docs(blog): add cover images for the two repatriated posts

### DIFF
--- a/docs/assets/rerank-ci-cover.svg
+++ b/docs/assets/rerank-ci-cover.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Rerank your CVEs in CI. A GitHub Action that scores Trivy and Grype findings by real risk and gates the build." font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b2a33"/>
+      <stop offset="1" stop-color="#0f3b49"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- a pipeline: scan -> vens -> gate; the gate passes -->
+  <line x1="912" y1="204" x2="912" y2="250" stroke="#3f8ba3" stroke-width="3" stroke-opacity="0.35"/>
+  <line x1="912" y1="312" x2="912" y2="358" stroke="#3f8ba3" stroke-width="3" stroke-opacity="0.35"/>
+  <g>
+    <rect x="815" y="158" width="194" height="46" rx="9" fill="#3f8ba3" opacity="0.15"/>
+    <rect x="815" y="250" width="194" height="46" rx="9" fill="#3f8ba3" opacity="0.15"/>
+    <rect x="815" y="358" width="194" height="46" rx="9" fill="#7fc4d6"/>
+    <path d="M872 381 l11 11 l22 -24" fill="none" stroke="#0b2a33" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="90" y="146" fill="#7fc4d6" font-size="25" font-weight="600" letter-spacing="4">VENS · CI</text>
+  <rect x="90" y="164" width="62" height="4" fill="#7fc4d6"/>
+
+  <text x="86" y="316" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">Rerank your</text>
+  <text x="86" y="400" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">CVEs in CI</text>
+
+  <text x="90" y="482" fill="#cfe1e7" font-size="32">A GitHub Action that scores Trivy and</text>
+  <text x="90" y="524" fill="#cfe1e7" font-size="32">Grype findings by real risk.</text>
+</svg>

--- a/docs/assets/stop-patching-cover.svg
+++ b/docs/assets/stop-patching-cover.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Stop patching CVEs that don't matter. Score every finding against your system, not the CVSS number." font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b2a33"/>
+      <stop offset="1" stop-color="#0f3b49"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- a scan's worth of findings; most don't matter, one does -->
+  <g>
+    <rect x="815" y="150" width="305" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+    <rect x="815" y="196" width="250" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+    <rect x="815" y="242" width="210" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+    <rect x="815" y="288" width="305" height="34" rx="6" fill="#7fc4d6"/>
+    <rect x="815" y="334" width="180" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+    <rect x="815" y="380" width="240" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+    <rect x="815" y="426" width="140" height="34" rx="6" fill="#3f8ba3" opacity="0.13"/>
+  </g>
+
+  <text x="90" y="146" fill="#7fc4d6" font-size="25" font-weight="600" letter-spacing="4">VENS · INTRODUCTION</text>
+  <rect x="90" y="164" width="62" height="4" fill="#7fc4d6"/>
+
+  <text x="86" y="300" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">Stop patching</text>
+  <text x="86" y="384" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">CVEs that don't</text>
+  <text x="86" y="468" fill="#ffffff" font-size="74" font-weight="800" letter-spacing="-1">matter</text>
+
+  <text x="90" y="540" fill="#cfe1e7" font-size="32">Score every finding against your system,</text>
+  <text x="90" y="582" fill="#cfe1e7" font-size="32">not the CVSS number.</text>
+</svg>

--- a/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
+++ b/docs/blog/posts/stop-patching-vulnerabilities-that-dont-matter.md
@@ -7,6 +7,8 @@ slug: stop-patching-vulnerabilities-that-dont-matter
 
 # Stop patching vulnerabilities that don't matter to you
 
+![Stop patching CVEs that don't matter](../../assets/stop-patching-cover.svg)
+
 Monday, 9 AM, coffee in hand. You open the Trivy report: **107 vulnerabilities**. You sort by CVSS, a **9.8 CRITICAL** sits at the top, and the emergency meeting starts.
 
 <!-- more -->

--- a/docs/blog/posts/vens-action-rerank-cves-in-ci.md
+++ b/docs/blog/posts/vens-action-rerank-cves-in-ci.md
@@ -7,6 +7,8 @@ slug: vens-action-rerank-cves-in-ci
 
 # vens-action: reranking Trivy/Grype CVEs by real risk in CI
 
+![Rerank your CVEs in CI](../../assets/rerank-ci-cover.svg)
+
 If you run Trivy or Grype in CI and triage the output by CVSS, this is the thing I wish I'd had two years ago.
 
 <!-- more -->


### PR DESCRIPTION
Follow-up to #238: the two repatriated posts (Stop patching CVEs / vens-action in CI) landed without their hero images because the cover commit came in after the squash-merge. Adds the two SVG covers (matching the existing benchmark-post style, brand teal) and the image refs.