### PR TITLE
docs: cite the benchmark DOI on the Choosing an LLM page

### DIFF
--- a/docs/concepts/choosing-a-model.md
+++ b/docs/concepts/choosing-a-model.md
@@ -7,6 +7,8 @@ Vens makes one LLM call per CVE batch, so the model is a direct cost and quality
 
 [**Which LLM Should Score Your CVEs?** (PDF)](../assets/vens-benchmark.pdf)
 
+Cite it: [`10.5281/zenodo.21775841`](https://doi.org/10.5281/zenodo.21775841).
+
 ---
 
 ## Recommendation


### PR DESCRIPTION
Adds the Zenodo DOI (10.5281/zenodo.21775841) under the paper link on the model-selection page.